### PR TITLE
Implement custom sorting cli option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ todoman.egg-info/
 .tox
 docs/_build/
 .coverage
+.hypothesis
 
 todoman/version.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,17 @@ import pytest
 from click.testing import CliRunner
 from hypothesis import HealthCheck, Verbosity, settings
 
+from todoman import model
+
 
 @pytest.fixture
-def config(tmpdir):
+def default_database(tmpdir):
+    return model.Database(path=str(tmpdir.mkdir('default')))
+
+
+@pytest.fixture
+def config(tmpdir, default_database):
     path = tmpdir.join('config')
-    tmpdir.mkdir('default')  # default calendar
     path.write('[main]\n'
                'path = {}/*\n'
                'date_format = %Y-%m-%d\n'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
+import os
+
 import pytest
 from click.testing import CliRunner
+from hypothesis import HealthCheck, Verbosity, settings
 
 
 @pytest.fixture
@@ -32,3 +35,18 @@ def create(tmpdir):
         )
 
     return inner
+
+
+settings.register_profile("ci", settings(
+    max_examples=1000,
+    verbosity=Verbosity.verbose,
+    suppress_health_check=[HealthCheck.too_slow]
+))
+settings.register_profile("deterministic", settings(
+    derandomize=True,
+))
+
+if os.getenv('DETERMINISTIC_TESTS', 'false').lower() == 'true':
+    settings.load_profile("deterministic")
+elif os.getenv('CI', 'false').lower() == 'true':
+    settings.load_profile("ci")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -169,15 +169,30 @@ def test_sorting_output(tmpdir, runner, create):
         'SUMMARY:bbb\n'
         'DUE;VALUE=DATE-TIME;TZID=ART:20160101T000000\n'
     )
-    result = runner.invoke(cli, ['list', '--sort', '-summary'])
-    assert not result.exception
-    assert 'aaa' in result.output.splitlines()[0]
-    assert 'bbb' in result.output.splitlines()[1]
 
-    result = runner.invoke(cli, ['list', '--sort', 'due'])
-    assert not result.exception
-    assert 'aaa' in result.output.splitlines()[0]
-    assert 'bbb' in result.output.splitlines()[1]
+    examples = [
+        ('-summary', ['aaa', 'bbb']),
+        ('due', ['aaa', 'bbb'])
+    ]
+
+    # Normal sorting, reversed by default
+    all_examples = [(['--sort', key], order) for key, order in examples]
+
+    # Testing --reverse, same exact output
+    all_examples.extend((['--reverse', '--sort', key], order)
+                        for key, order in examples)
+
+    # Testing --no-reverse
+    all_examples.extend((['--no-reverse', '--sort', key], reversed(order))
+                        for key, order in examples)
+
+    for args, order in all_examples:
+        result = runner.invoke(cli, ['list'] + args)
+        assert not result.exception
+        lines = result.output.splitlines()
+        for i, task in enumerate(order):
+            assert task in lines[i]
+
 
 # TODO: test aware/naive datetime sorting
 # TODO: test --grep

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -113,7 +113,6 @@ def test_delete(tmpdir, runner, create):
     assert len(result.output.splitlines()) == 0
 
 
-
 def test_dtstamp(tmpdir, runner, create):
     """
     Test that we add the DTSTAMP to new entries as per RFC5545.
@@ -127,7 +126,7 @@ def test_dtstamp(tmpdir, runner, create):
     assert todo.dtstamp.tzinfo is pytz.utc
 
 
-def test_sorting(tmpdir, runner):
+def test_sorting_fields(tmpdir, runner):
     for i in range(1, 10):
         days = datetime.timedelta(days=i)
 
@@ -154,6 +153,28 @@ def test_sorting(tmpdir, runner):
         assert result.exit_code == 0
 
     run_test()
+
+
+def test_sorting_output(tmpdir, runner, create):
+    create(
+        'test.ics',
+        'SUMMARY:aaa\n'
+        'DUE;VALUE=DATE-TIME;TZID=ART:20160102T000000\n'
+    )
+    create(
+        'test2.ics',
+        'SUMMARY:bbb\n'
+        'DUE;VALUE=DATE-TIME;TZID=ART:20160101T000000\n'
+    )
+    result = runner.invoke(cli, ['list', '--sort', '-summary'])
+    assert not result.exception
+    assert 'aaa' in result.output.splitlines()[0]
+    assert 'bbb' in result.output.splitlines()[1]
+
+    result = runner.invoke(cli, ['list', '--sort', 'due'])
+    assert not result.exception
+    assert 'aaa' in result.output.splitlines()[0]
+    assert 'bbb' in result.output.splitlines()[1]
 
 # TODO: test aware/naive datetime sorting
 # TODO: test --grep

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,6 @@
 import datetime
 
 import hypothesis.strategies as st
-import icalendar
 import pytest
 import pytz
 from hypothesis import given
@@ -126,7 +125,7 @@ def test_dtstamp(tmpdir, runner, create):
     assert todo.dtstamp.tzinfo is pytz.utc
 
 
-def test_sorting_fields(tmpdir, runner):
+def test_sorting_fields(tmpdir, runner, default_database):
     tasks = []
     for i in range(1, 10):
         days = datetime.timedelta(days=i)
@@ -137,9 +136,7 @@ def test_sorting_fields(tmpdir, runner):
         todo.summary = 'harhar{}'.format(i)
         tasks.append(todo)
 
-        ical = icalendar.Calendar()
-        ical.add_component(todo.todo)
-        tmpdir.join('default/test{}.ics'.format(i)).write(ical.to_ical())
+        default_database.save(todo)
 
     fields = tuple(field for field in dir(Todo) if not
                    field.startswith('_'))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -127,6 +127,7 @@ def test_dtstamp(tmpdir, runner, create):
 
 
 def test_sorting_fields(tmpdir, runner):
+    tasks = []
     for i in range(1, 10):
         days = datetime.timedelta(days=i)
 
@@ -134,6 +135,7 @@ def test_sorting_fields(tmpdir, runner):
         todo['due'] = datetime.datetime.now() + days
         todo['created_at'] = datetime.datetime.now() - days
         todo['summary'] = 'harhar{}'.format(i)
+        tasks.append(todo)
         ical = icalendar.Calendar()
         ical.add_component(todo)
 
@@ -151,6 +153,7 @@ def test_sorting_fields(tmpdir, runner):
         result = runner.invoke(cli, ['list', '--sort', sort_key])
         assert not result.exception
         assert result.exit_code == 0
+        assert len(result.output.strip().splitlines()) == len(tasks)
 
     run_test()
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -131,14 +131,14 @@ def test_sorting_fields(tmpdir, runner):
     for i in range(1, 10):
         days = datetime.timedelta(days=i)
 
-        todo = icalendar.Todo()
-        todo['due'] = datetime.datetime.now() + days
-        todo['created_at'] = datetime.datetime.now() - days
-        todo['summary'] = 'harhar{}'.format(i)
+        todo = Todo()
+        todo.due = datetime.datetime.now() + days
+        todo.created_at = datetime.datetime.now() - days
+        todo.summary = 'harhar{}'.format(i)
         tasks.append(todo)
-        ical = icalendar.Calendar()
-        ical.add_component(todo)
 
+        ical = icalendar.Calendar()
+        ical.add_component(todo.todo)
         tmpdir.join('default/test{}.ics'.format(i)).write(ical.to_ical())
 
     fields = tuple(field for field in dir(Todo) if not

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -191,7 +191,10 @@ def delete(ctx, ids):
 @click.option('--category', help='Only show tasks with category containg TEXT')
 @click.option('--grep', help='Only show tasks with message containg TEXT')
 @click.option('--sort', help='Sort tasks using these fields')
-def list(ctx, lists, all, urgent, location, category, grep, sort):
+@click.option('--reverse/--no-reverse', default=True,
+              help='Sort tasks in reverse order (see --sort). '
+              'Defaults to true.')
+def list(ctx, lists, all, urgent, location, category, grep, sort, reverse):
     """
     List unfinished tasks.
 
@@ -226,7 +229,7 @@ def list(ctx, lists, all, urgent, location, category, grep, sort):
                    ))
         ),
         key=get_task_sort_function(fields=sort),
-        reverse=True
+        reverse=reverse
     )
     ids = {}
 

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -5,7 +5,7 @@ from os.path import expanduser, isdir, join
 import click
 
 from .configuration import load_config
-from .main import dump_idfile, get_todo, task_sort_func
+from .main import dump_idfile, get_task_sort_function, get_todo
 from .model import Database, Todo
 from .ui import EditState, TodoEditor, TodoFormatter
 
@@ -190,7 +190,8 @@ def delete(ctx, ids):
 @click.option('--location', help='Only show tasks with location containg TEXT')
 @click.option('--category', help='Only show tasks with category containg TEXT')
 @click.option('--grep', help='Only show tasks with message containg TEXT')
-def list(ctx, lists, all, urgent, location, category, grep):
+@click.option('--sort', help='Sort tasks using these fields')
+def list(ctx, lists, all, urgent, location, category, grep, sort):
     """
     List unfinished tasks.
 
@@ -208,6 +209,7 @@ def list(ctx, lists, all, urgent, location, category, grep):
     pattern = re.compile(grep) if grep else None
     # FIXME: When running with no command, this somehow ends up empty:
     lists = lists or ctx.obj['db'].values()
+    sort = sort.split(',') if sort else None
 
     todos = sorted(
         (
@@ -223,7 +225,7 @@ def list(ctx, lists, all, urgent, location, category, grep):
                    pattern.search(todo.description)
                    ))
         ),
-        key=lambda x: task_sort_func(x[1]),
+        key=get_task_sort_function(fields=sort),
         reverse=True
     )
     ids = {}

--- a/todoman/main.py
+++ b/todoman/main.py
@@ -30,25 +30,45 @@ def dump_idfile(ids):
         json.dump(list(ids.items()), f)
 
 
-def task_sort_func(todo):
-    """
-    Auxiliary function used to sort todos.
+def get_task_sort_function(fields):
+    if not fields:
+        fields = [
+            '-priority',
+            'is_completed',
+            'due',
+            '-created_at',
+        ]
 
-    We put the most important items on the bottom of the list because the
-    terminal scrolls with the output.
+    def sort_func(args):
+        """
+        Auxiliary function used to sort todos.
 
-    Items with an immediate due date are considered more important that
-    those for which we have more time.
-    """
+        We put the most important items on the bottom of the list because the
+        terminal scrolls with the output.
 
-    rv = (
-        -todo.priority,
-        todo.is_completed,
-        (todo.due.timestamp() if todo.due else float('inf')),
-        (-todo.created_at.timestamp() if todo.created_at else 0),
-        todo.uid  # make ordering deterministic, even if it makes no sense
-    )
-    return rv
+        Items with an immediate due date are considered more important that
+        those for which we have more time.
+        """
+        db, todo = args
+        rv = []
+        for field in fields:
+            neg = field.startswith('-')
+            if neg:
+                # Remove that '-'
+                field = field[1:]
+            if field == 'due':
+                # TODO: Some better method to deal with these special cases?
+                value = todo.due.timestamp() if todo.due else float('inf')
+            elif field == 'created_at':
+                value = todo.created_at.timestamp() if todo.created_at else 0
+            else:
+                value = getattr(todo, field, "")
+            value = -value if neg and value else value
+            rv.append(value)
+
+        return rv
+
+    return sort_func
 
 
 def get_todo(databases, todo_id):

--- a/todoman/main.py
+++ b/todoman/main.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import os
@@ -68,7 +69,14 @@ def get_task_sort_function(fields):
             value = getattr(todo, field)
             if field in ('due', 'created_at', 'completed_at'):
                 value = value.timestamp() if value else float('inf')
-            value = -value if neg and value else value
+
+            if neg and value:
+                # This "negates" the value, whichever type. The lambda is the
+                # same as Python 2's `cmp` builtin, but with inverted output
+                # (-1 instead of 1 etc).
+                value = functools.cmp_to_key(
+                    lambda a, b: -((a > b) - (a < b)))(value)
+
             rv.append(value)
 
         return rv

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -122,7 +122,7 @@ class Todo:
     @property
     def categories(self):
         categories = self.todo.get('categories', '').split(',')
-        return filter(None, categories)
+        return tuple(filter(None, categories))
 
     @categories.setter
     def categories(self, categories):

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,12 @@ envlist = py33, py34, py35, flake8, isort
 deps =
   pytest
   pytest-cov
+  hypothesis
   -rrequirements.txt
 commands = py.test --cov todoman
 setenv =
   PYTHONPATH = {toxinidir}
+passenv = CI
 
 [testenv:flake8]
 skip_install = True


### PR DESCRIPTION
Implement `todo list --sort FIELD1,FIELD2`, to allow custom sorting.

Though the code seems complex, there's no noticeable difference between this sorting mechanism and the original one, though I'd love some feedback on how to de-uglify this.

Code can also be used to make the default sort order configurable.