### PR TITLE
Add basic editing shortcuts to text widgets

### DIFF
--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -8,6 +8,8 @@ import parsedatetime
 import urwid
 from dateutil.tz import tzlocal
 
+from . import widgets
+
 
 class EditState:
     none = object()
@@ -36,11 +38,13 @@ class TodoEditor:
         else:
             due = ""
 
-        self._summary = urwid.Edit(edit_text=todo.summary)
-        self._description = urwid.Edit(edit_text=todo.description,
-                                       multiline=True)
-        self._location = urwid.Edit(edit_text=todo.location)
-        self._due = urwid.Edit(edit_text=due)
+        self._summary = widgets.ExtendedEdit(edit_text=todo.summary)
+        self._description = widgets.ExtendedEdit(
+            edit_text=todo.description,
+            multiline=True,
+        )
+        self._location = widgets.ExtendedEdit(edit_text=todo.location)
+        self._due = widgets.ExtendedEdit(edit_text=due)
         self._completed = urwid.CheckBox("", state=todo.is_completed)
         self._urgent = urwid.CheckBox("", state=todo.priority != 0)
 

--- a/todoman/widgets.py
+++ b/todoman/widgets.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2016 Hugo Osvaldo Barrera
+# Copyright (c) 2013-2016 Christian Geier et al.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import re
+
+import urwid
+
+
+class ExtendedEdit(urwid.Edit):
+    """A text editing widget supporting some more editing commands"""
+    def keypress(self, size, key):
+        if key == 'ctrl w':
+            self._delete_word()
+        elif key == 'ctrl u':
+            self._delete_till_beginning_of_line()
+        elif key == 'ctrl k':
+            self._delete_till_end_of_line()
+        elif key == 'ctrl a':
+            self._goto_beginning_of_line()
+        elif key == 'ctrl e':
+            self._goto_end_of_line()
+        elif key == 'ctrl d':
+            self._delete_forward_letter()
+        # TODO: alt b, alt f
+        else:
+            return super(ExtendedEdit, self).keypress(size, key)
+
+    def _delete_forward_letter(self):
+        text = self.get_edit_text()
+        pos = self.edit_pos
+        text = text[:pos] + text[pos + 1:]
+        self.set_edit_text(text)
+
+    def _delete_word(self):
+        """delete word before cursor"""
+        text = self.get_edit_text()
+        t = text[:self.edit_pos].rstrip()
+
+        words = re.findall(r'[\w]+|[^\w\s]', t, re.UNICODE)
+        if t == '':
+            f_text = t
+        else:
+            f_text = t[:len(t) - len(words[-1])]
+
+        self.set_edit_text(f_text + text[self.edit_pos:])
+        self.set_edit_pos(len(f_text))
+
+    def _delete_till_beginning_of_line(self):
+        """delete till start of line before cursor"""
+        text = self.get_edit_text()
+        sol = text.rfind('\n', self.edit_pos)
+
+        if sol == -1:
+            sol = 0
+        before_line = text[:sol]
+
+        self.set_edit_text(before_line + text[self.edit_pos:])
+        self.set_edit_pos(sol)
+
+    def _delete_till_end_of_line(self):
+        """delete till end of line before cursor"""
+        text = self.get_edit_text()
+        eol = text.find('\n', self.edit_pos)
+
+        if eol == -1:
+            after_eol = ''
+        else:
+            after_eol = text[eol:]
+
+        self.set_edit_text(text[:self.edit_pos] + after_eol)
+
+    def _goto_beginning_of_line(self):
+        text = self.get_edit_text()
+        sol = text.rfind('\n', 0, self.edit_pos)
+        if sol == -1:
+            sol = 0
+        self.set_edit_pos(sol)
+
+    def _goto_end_of_line(self):
+        text = self.get_edit_text()
+        eol = text.find('\n', self.edit_pos)
+        if eol == -1:
+            eol = len(text)
+        self.set_edit_pos(eol)


### PR DESCRIPTION
Some still-pending shortcuts:

 * <kbd>ctrl</kbd>+<kbd>s</kbd>: save (and exit?)
 * <kbd>tab</kbd>: next element (next input block or button)
 * <kbd>alt</kbd>+<kbd>f</kbd>: forward word
 * <kbd>alt</kbd>+<kbd>b</kbd>: backward word

I'd also like to possibly move these widgets to a separate project ("urwid-extras"?) so I can stop copy-pasting stuff from khal.

@geier: Thoughts?