### PR TITLE
Fix #24: return a KeyWrapper when negating values

### DIFF
--- a/todoman/main.py
+++ b/todoman/main.py
@@ -70,7 +70,7 @@ def get_task_sort_function(fields):
             if field in ('due', 'created_at', 'completed_at'):
                 value = value.timestamp() if value else float('inf')
 
-            if neg and value:
+            if neg:
                 # This "negates" the value, whichever type. The lambda is the
                 # same as Python 2's `cmp` builtin, but with inverted output
                 # (-1 instead of 1 etc).


### PR DESCRIPTION
When performing a comparison with a `functools.KeyWrapper` it is necessary to compare it with another `functools.KeyWrapper`; a `functools.KeyWrapper` should be returned even when the value is a falsy one.

Fixes #24.