### PR TITLE
Fix #27: list "todo" tasks before "done" important tasks

### DIFF
--- a/todoman/main.py
+++ b/todoman/main.py
@@ -37,8 +37,8 @@ def dump_idfile(ids):
 def get_task_sort_function(fields):
     if not fields:
         fields = [
-            '-priority',
             'is_completed',
+            '-priority',
             'due',
             '-created_at',
         ]


### PR DESCRIPTION
This PR improves the `todo list -a` command sorting by showing every task sorted by `status` and then by `priority`, which makes `done` tasks (even "important" ones) appear together, before `todo` tasks.

Fixes #27.