### PR TITLE
Add `default_list` in config for new todos

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -24,6 +24,9 @@ Main section
    TTY (value ``auto``). Set to ``never`` to disable colored output entirely,
    or ``always`` to enable it regardless. This can be overridden with the
    ``--color`` option.
+ * ``default_list``: The default list for adding a todo. If you do not specify
+   this option, you must use the ``--list`` / ``-l`` option every time you add
+   a todo.
 
 Sample configuration
 --------------------

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -125,6 +125,24 @@ def test_dtstamp(tmpdir, runner, create):
     assert todo.dtstamp.tzinfo is pytz.utc
 
 
+def test_default_list(tmpdir, runner, create):
+    """
+    Test the default_list config parameter
+    """
+    result = runner.invoke(cli, ['new', 'test default list'])
+    assert result.exception
+
+    path = tmpdir.join('config')
+    path.write('default_list = default\n', 'a')
+
+    result = runner.invoke(cli, ['new', 'test default list'])
+    assert not result.exception
+
+    db = Database(str(tmpdir + '/default'))
+    todo = list(db.todos.values())[0]
+    assert todo.summary == 'test default list'
+
+
 def test_sorting_fields(tmpdir, runner, default_database):
     tasks = []
     for i in range(1, 10):

--- a/todoman.conf.sample
+++ b/todoman.conf.sample
@@ -2,3 +2,4 @@
 # A glob expression which matches all directories relevant.
 path = ~/.local/share/calendars/*
 date_format = %Y-%m-%d
+default_list = Personal

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -21,6 +21,14 @@ def _validate_lists_param(ctx, param=None, lists=None):
 
 
 def _validate_list_param(ctx, param=None, name=None):
+    if name is None:
+        if 'default_list' in ctx.obj['config']['main']:
+            name = ctx.obj['config']['main']['default_list']
+        else:
+            raise click.BadParameter(
+                "{}. You must set 'default_list' or use -l."
+                .format(name)
+            )
     if name in ctx.obj['db']:
         return ctx.obj['db'][name]
     else:
@@ -90,7 +98,7 @@ except ImportError:
 @cli.command()
 @click.argument('summary', nargs=-1)
 @click.option('--list', '-l', callback=_validate_list_param,
-              help='The list to create the task in.', required=True)
+              help='The list to create the task in.')
 @click.option('--due', '-d', default='', callback=_validate_due_param,
               help=('The due date of the task, in the format specified in the '
                     'configuration file.'))


### PR DESCRIPTION
Create todos fastly and easily.

Maybe, if  there is only one list, it should automaticaly considered as the default one.