### PR TITLE
Programmatically generate output of --help

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,12 @@ py36:
   script:
     - tox -e py36
 
+docs:
+  stage: test
+  image: python:3.6
+  script:
+    - tox -e docs
+
 flake8:
   image: python:latest
   stage: style

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ env:
   - BUILD=py
   - BUILD=flake8
   - BUILD=isort
+  - BUILD=docs
+
+matrix:
+  exclude:
+    # Sphinx requires python 3.4 or above
+    - python: 3.3
+      env: BUILD=docs
 
 addons:
   apt:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ import todoman
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx_autorun',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
 ]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,26 +4,11 @@ Usage
 Todoman usage is `CLI`_ based (thought there are some TUI bits, and the
 intentions is to also provide a fully `TUI`_-based interface).
 
-First of all, the classic usage output::
+First of all, the classic usage output:
 
-    Usage: todo [OPTIONS] COMMAND [ARGS]...
+.. runblock:: console
 
-    Options:
-      --human-time / --no-human-time  Accept informal descriptions such as
-                                      "tomorrow" instead of a properly formatted
-                                      date.
-      --version                       Show the version and exit.
-      --help                          Show this message and exit.
-
-    Commands:
-      done   Mark a task as done.
-      edit   Edit a task interactively.
-      flush  Delete done tasks.
-      list   List unfinished tasks.
-      new    Create a new task with SUMMARY.
-      repl   Start an interactive shell.
-      shell  Start an interactive shell.
-      show   Show details about a task.
+    $ todo --help
 
 The default action is ``list``, which outputs all tasks for all calendars, each
 with a non-permanent unique id::

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+sphinx_autorun>=1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,10 @@ commands = python setup.py bdist_wheel
 skip_install = True
 commands = python setup.py sdist
 
+[testenv:docs]
+commands =
+  pip install -rrequirements-docs.txt
+  make -C docs html
+
 [flake8]
 exclude=.tox,build,docs


### PR DESCRIPTION
The docs include the output of `todo --help`, but it was a copy-paste
which easily went out of date.

Include this output programmatically by actually running `todo --help`.

---

This PR is blocked by [this](https://bitbucket.org/birkenfeld/sphinx-contrib/pull-requests/130/) upstream issue, and cannot be merged until that issue is merged+released.
