### PR TITLE
Adding a copy command

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -113,6 +113,24 @@ def test_delete(tmpdir, runner, create):
     assert len(result.output.splitlines()) == 0
 
 
+def test_copy(tmpdir, runner, create):
+    tmpdir.mkdir('other_list')
+    create(
+        'test.ics',
+        'SUMMARY:test_copy\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert not result.exception
+    assert 'test_copy' in result.output
+    assert 'other_list' not in result.output
+    result = runner.invoke(cli, ['copy', '-l', 'other_list', '1'])
+    assert not result.exception
+    result = runner.invoke(cli, ['list'])
+    assert not result.exception
+    assert 'test_copy' in result.output
+    assert 'other_list' in result.output
+
+
 def test_dtstamp(tmpdir, runner, create):
     """
     Test that we add the DTSTAMP to new entries as per RFC5545.

--- a/todoman/main.py
+++ b/todoman/main.py
@@ -99,3 +99,12 @@ def get_todo(databases, todo_id):
         print("No todo with id {}.".format(todo_id))
         sys.exit(-2)
         # raise ValueError("No such todo {}.".format(todo_id)) from e
+
+
+def get_todos(ctx, ids):
+    todos = []
+    for id in ids:
+        todo, database = get_todo(ctx.obj['db'], id)
+        click.echo(ctx.obj['formatter'].compact(todo, database))
+        todos.append(todo)
+    return todos, database


### PR DESCRIPTION
to copy an item into another list.

I usually like to copy items from public read-only calendars to the one I share with my relatives, so I would really appreciate this little functionality.

If you agree with this PR, I'll probably make another similar one for moving items from an agenda to another (ie. copy + delete). This can be useful when someone mistakenly creates a new item in a wrong list.