### PR TITLE
Remove ansi dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ icalendar
 urwid
 pyxdg
 atomicwrites
-ansi>=0.1.3
 parsedatetime

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -5,7 +5,6 @@ from os.path import normpath, split
 from uuid import uuid4
 
 import icalendar
-from ansi.colour.rgb import rgb8
 from atomicwrites import AtomicWriter
 from dateutil.tz import tzlocal
 
@@ -305,7 +304,7 @@ class Database:
     def color_ansi(self):
         rv = self.color_rgb
         if rv:
-            return rgb8(*rv)
+            return '\33[38;2;{!s};{!s};{!s}m'.format(*rv)
 
     def __str__(self):
         return self.name

--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from time import mktime
+import click
 
-import ansi.colour.fg
-import ansi.colour.fx
-import ansi.sequence
 import parsedatetime
 import urwid
 from dateutil.tz import tzlocal
@@ -199,11 +197,7 @@ class TodoFormatter:
 
         due = self.format_date(todo.due)
         if todo.due and todo.due <= self.now and not todo.is_completed:
-            due = '{}{}{}'.format(
-                ansi.colour.fg.red,
-                due,
-                ansi.colour.fx.reset
-            )
+            due = click.style(due, fg='red')
 
         summary = todo.summary
         list = self.format_database(database)
@@ -250,6 +244,5 @@ class TodoFormatter:
             return None
 
     def format_database(self, database):
-        return '{}@{}{}'.format(database.color_ansi or '',
-                                database.name,
-                                ansi.colour.fx.reset)
+        return '{}@{}'.format(database.color_ansi or '',
+                              click.style(database.name))


### PR DESCRIPTION
Most colorcodes are provided by Click, use Khal's colorcode conversion.
This yields different colors than the old algorithm, but provides more
accurate results for modern terminals.