### PR TITLE
Use TOML for the configuration file

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -1,19 +1,21 @@
 Configuring
 ===========
 
-You'll need to configure Todoman before the first usage, using its simple
-ini-like configuration file.
+You'll need to configure todoman before the first usage. The configuration file
+,uses TOML_, and is described below.
+
+.. _TOML: https://github.com/toml-lang/toml
 
 Configuration File
 ------------------
 
 The configuration file should be placed in
-``$XDG_CONFIG_DIR/todoman/todoman.conf``. ``$XDG_CONFIG_DIR`` defaults to
+``$XDG_CONFIG_DIR/todoman/todoman.toml``. ``$XDG_CONFIG_DIR`` defaults to
 ``~/.config`` is most situations, so this will generally be
-``~/.config/todoman/todoman.conf``.
+``~/.config/todoman/todoman.toml``.
 
-Main section
-~~~~~~~~~~~~
+Main table
+~~~~~~~~~~
 
  * ``path``: A glob pattern matching the directories where your todos are
    located.
@@ -36,8 +38,8 @@ directory inside ``~/.local/share/calendars/``, and use the ISO-8601 date
 format (note that this is the default format, so this particular declaration is
 redundant).
 
-.. literalinclude:: ../todoman.conf.sample
-  :language: ini
+.. literalinclude:: ../todoman.toml.sample
+  :language: toml
 
 Color and displayname
 ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ icalendar
 jsonschema
 parsedatetime
 pyxdg
-toml
+pytoml
 urwid

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 atomicwrites
 click>=6.0
 icalendar
+jsonschema
 parsedatetime
 pyxdg
 toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ click>=6.0
 icalendar
 parsedatetime
 pyxdg
+toml
 urwid

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ def default_database(tmpdir):
 def config(tmpdir, default_database):
     path = tmpdir.join('config')
     path.write('[main]\n'
-               'path = {}/*\n'
-               'date_format = %Y-%m-%d\n'
+               'path = "{}/*"\n'
+               'date_format = "%Y-%m-%d"\n'
                .format(str(tmpdir)))
     return path
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -174,7 +174,7 @@ def test_default_list(tmpdir, runner, create):
     assert result.exception
 
     path = tmpdir.join('config')
-    path.write('default_list = default\n', 'a')
+    path.write('default_list = "default"\n', 'a')
 
     result = runner.invoke(cli, ['new', 'test default list'])
     assert not result.exception

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,3 +28,61 @@ def test_xdg_nonexistant(runner):
     )
     assert result.exception
     assert str(result.exception) == "No Configuration file found"
+
+
+def test_sane_config(config, runner):
+    config.write(
+        '[main]\n'
+        'color = "auto"\n'
+        'date_format = "%Y-%m-%d"\n'
+        'path = "/"\n'
+    )
+    result = runner.invoke(cli)
+    assert not result.exception
+
+
+def test_invalid_color(config, runner):
+    config.write(
+        '[main]\n'
+        'color = 12\n'
+        'path = "/"\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert "12 is not of type 'string'" in result.exception.args[0]
+
+
+def test_missing_path(config, runner):
+    config.write(
+        '[main]\n'
+        'color = "auto"\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert "'path' is a required property" in result.exception.args[0]
+
+
+def test_extra_field(config, runner):
+    config.write(
+        '[main]\n'
+        'color = "auto"\n'
+        'date_format = "%Y-%m-%d"\n'
+        'path = "/"\n'
+        'blah = "false"\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert "Additional properties are not allowed" in result.exception.args[0]
+
+
+def test_extra_table(config, runner):
+    config.write(
+        '[main]\n'
+        'date_format = "%Y-%m-%d"\n'
+        'path = "{}/*"\n'
+        '[extra]\n'
+        'color = "auto"\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert "Additional properties are not allowed" in result.exception.args[0]

--- a/todoman.conf.sample
+++ b/todoman.conf.sample
@@ -1,5 +1,0 @@
-[main]
-# A glob expression which matches all directories relevant.
-path = ~/.local/share/calendars/*
-date_format = %Y-%m-%d
-default_list = Personal

--- a/todoman.toml.sample
+++ b/todoman.toml.sample
@@ -1,0 +1,5 @@
+[main]
+# A glob expression which matches all directories relevant.
+path = "~/.local/share/calendars/*"
+date_format = "%Y-%m-%d"
+default_list = "Personal"

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -85,12 +85,12 @@ def cli(ctx, human_time, color):
     ctx.obj = {}
     ctx.obj['config'] = config
     ctx.obj['formatter'] = TodoFormatter(
-        config.get('main', 'date_format', fallback='%Y-%m-%d'),
+        config['main']['date_format'],
         human_time
     )
     ctx.obj['db'] = databases = {}
 
-    color = color or ctx.obj['config']['main'].get('color', 'auto')
+    color = color or config['main']['color']
     if color == 'always':
         ctx.color = True
     elif color == 'never':

--- a/todoman/configuration.py
+++ b/todoman/configuration.py
@@ -2,7 +2,7 @@ import copy
 from os import environ
 from os.path import exists, join
 
-import toml
+import pytoml
 import xdg.BaseDirectory
 from click import ClickException
 from jsonschema import validate
@@ -80,7 +80,7 @@ def load_config():
 def _load_config_impl(path):
     config = copy.deepcopy(defaults)
     with open(path) as conffile:
-        explicit = toml.loads(conffile.read())
+        explicit = pytoml.loads(conffile.read())
     merge_dicts(config, explicit)
     try:
         validate(config, schema)


### PR DESCRIPTION
Use TOML as a config format:
 * TOML is clearer than our current config format, unambiguous, and other pros I believe we already know.
 * It may be a bit premature though, since the current format hasn't given any problems.
 * TOML is becoming a lot more popular, especially in the python community.

Set default values when we load the config, rather than scatter them around the app, which should make everything a bit cleaner.

Closes #31