### PR TITLE
List authors and document copyright ownership

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,16 @@
+Authors
+=======
+
+All contributors retain copyright to their contributions. Below is a list of
+authors who've contributed code to the project, or who wrote code elsewhere
+that we reused here.
+
+We manually track this since commit author *does not* equal code author.
+
+* Benjamin Frank <ben+gitlab@pipsfrank.de>
+* Christian Geier <geier@lostpackets.de>
+* Guilhem Saurel <guilhem.saurel@gmail.com>
+* Hugo Osvaldo Barrera <hugo@barrera.io>
+* José Ribeiro <hello@jlbribeiro.com>
+* Markus Unterwaditzer <markus@unterwaditzer.net>
+* Thomas Glanzmann <thomas@glanzmann.de>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,11 @@ There is very little unit test coverage for now, and they can be run via
 [tox][tox]. Any bugfixes should include a test which would fail without the fix
 applied.
 
+Authorship
+----------
+
+If contributing to the project, please add yourself to ``AUTHORS.rst``.
+
 [requirements]: requirements.txt
 [pep8]: http://python.org/dev/peps/pep-0008/
 [tox]: http://tox.testrun.org


### PR DESCRIPTION
Someone (I believe that it was @untitaker) mentioned that #5 was a bad idea since it ommited authors of copy-pasted code, and things like that.

@untitaker: I'd like your opinion on whether this is okay (or you want to chime in, in some way). It looks pretty much like what [vdirsyncer](https://github.com/pimutils/vdirsyncer) and [khal](https://github.com/pimutils/khal) are doing.

@geier I'm adding you, since I copied some code from khal, just letting you know, hope it's okay.

Closes #5