### PR TITLE
Validate the configuration file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 atomicwrites
 click>=6.0
+configobj
 icalendar
 parsedatetime
 python-dateutil

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import pytest
 import xdg
 from click.testing import CliRunner
 
@@ -56,3 +57,66 @@ def test_xdg_existant(runner, tmpdir, config):
         # Make sure we ALWAYS set this back to the origianl value, even if the
         # test failed.
         xdg.BaseDirectory.xdg_config_dirs = original_dirs
+
+
+def test_sane_config(config, runner, tmpdir):
+    config.write(
+        '[main]\n'
+        'color = auto\n'
+        'date_format = %Y-%m-%d\n'
+        'path = /\n'
+        'cache_path = {}\n'.format(tmpdir.join('cache.sqlite'))
+    )
+    result = runner.invoke(cli)
+    assert not result.exception
+
+
+def test_invalid_color(config, runner):
+    config.write(
+        '[main]\n'
+        'color = 12\n'
+        'path = "/"\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert "Error: Invalid color setting: Choose from always, never, auto." \
+        in result.output
+
+
+def test_missing_path(config, runner):
+    config.write(
+        '[main]\n'
+        'color = auto\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert ("Error: path is missing from the ['main'] section of the "
+            "configuration file") in result.output
+
+
+@pytest.mark.xfail(reason="Not implemented")
+def test_extra_entry(config, runner):
+    config.write(
+        '[main]\n'
+        'color = auto\n'
+        'date_format = %Y-%m-%d\n'
+        'path = /\n'
+        'blah = false\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert "Invalid configuration entry" in result.output
+
+
+@pytest.mark.xfail(reason="Not implemented")
+def test_extra_section(config, runner):
+    config.write(
+        '[main]\n'
+        'date_format = %Y-%m-%d\n'
+        'path = /\n'
+        '[extra]\n'
+        'color = auto\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert result.exception
+    assert "Invalid configuration section" in result.output

--- a/todoman/configuration.py
+++ b/todoman/configuration.py
@@ -1,35 +1,73 @@
-from configparser import ConfigParser
-from os import environ
+import os
 from os.path import exists, join
 
 import xdg.BaseDirectory
-from click import ClickException
+from configobj import ConfigObj, flatten_errors
+from validate import Validator
 
 from . import __documentation__
 
 
-def load_config():
-    custom_path = environ.get('TODOMAN_CONFIG')
+class ConfigurationException(Exception):
+    def __init__(self, msg):
+        super().__init__((
+            '{}\nFor details on the configuration format and a sample file, '
+            'see\n{}configure.html'
+        ).format(msg, __documentation__))
+
+
+def expand_path(path):
+    """expands `~` as well as variable names"""
+    if path is None:
+        return False
+    return os.path.expanduser(os.path.expandvars(path))
+
+
+def validate_cache_path(path):
+    if path:
+        return expand_path(path)
+    else:
+        return os.path.join(
+            xdg.BaseDirectory.xdg_cache_home,
+            'todoman/cache.sqlite3',
+        )
+
+
+def find_config():
+    custom_path = os.environ.get('TODOMAN_CONFIG')
     if custom_path:
         if not exists(custom_path):
-            raise ClickException(
+            raise ConfigurationException(
                 "Configuration file {} does not exist".format(custom_path)
             )
-        return _load_config_impl(custom_path)
+        return custom_path
 
     for d in xdg.BaseDirectory.xdg_config_dirs:
         path = join(d, 'todoman', 'todoman.conf')
         if exists(path):
-            return _load_config_impl(path)
+            return path
 
-    raise ClickException(
+    raise ConfigurationException(
         "No configuration file found.\n\n"
-        "For details on the configuration format and a sample file, see\n"
-        "{}configure.html".format(__documentation__)
     )
 
 
-def _load_config_impl(path):
-    config = ConfigParser(interpolation=None)
-    config.read(path)
+def load_config():
+    path = find_config()
+    specpath = os.path.join(os.path.dirname(__file__), 'confspec.ini')
+    validator = Validator({
+        'expand_path': expand_path,
+        'cache_path': validate_cache_path,
+    })
+
+    config = ConfigObj(path, configspec=specpath, file_error=True)
+    validation = config.validate(validator, preserve_errors=True)
+
+    for section, key, error in flatten_errors(config, validation):
+        if not error:
+            raise ConfigurationException(
+                ('{} is missing from the {} section of the configuration ' +
+                 'file').format(key, section)
+            )
+
     return config

--- a/todoman/confspec.ini
+++ b/todoman/confspec.ini
@@ -1,0 +1,6 @@
+[main]
+path = expand_path()
+color = option('always', 'auto', 'never', default='auto')
+date_format = string(default='%Y-%m-%d')
+default_list = string(default=None)
+cache_path = cache_path(default='')


### PR DESCRIPTION
Validate the configuration file at startup, and only pass a ConfigObj around, centralizing all validation and defaults in a single place.

Fixes #31