### PR TITLE
Use the system date format by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+v2.2.0
+------
+
+* Use the system's date format as a default.
+
 v2.1.0
 ------
 

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -1,5 +1,6 @@
 import functools
 import glob
+import locale
 from datetime import timedelta
 from os.path import expanduser, isdir
 
@@ -110,6 +111,9 @@ def cli(ctx, color, porcelain):
 
     if not ctx.invoked_subcommand:
         ctx.invoke(cli.commands["list"])
+
+    # Make python actually use LC_TIME, or the user's locale settings
+    locale.setlocale(locale.LC_TIME, "")
 
 
 try:

--- a/todoman/confspec.ini
+++ b/todoman/confspec.ini
@@ -1,7 +1,7 @@
 [main]
 path = expand_path()
 color = option('always', 'auto', 'never', default='auto')
-date_format = string(default='%Y-%m-%d')
+date_format = string(default='%x')
 default_list = string(default=None)
 default_due = integer(default=24)
 cache_path = cache_path(default='')


### PR DESCRIPTION
The current date format was ISO8601 (which is great!), but it's honestly a matter of preference. Use the system's default date format if none is specified, since it seems saner to respect the user's system settings that impose out own preference.