### PR TITLE
Strip the human_time flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ releases, in reverse chronological order.
 v2.1.0
 ------
 
+* The ``--no-human-time`` flag is gone. Integrations/scripts might want to look
+  at ``--porcelain`` as an alternative.
 * Fix crash when running ``todo new``.
 * Fixes some issues when filtering todos from different timezones.
 * Attempt to create the cache file's directory if it does not exist.

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -70,9 +70,6 @@ _interactive_option = click.option(
 
 
 @click.group(invoke_without_command=True)
-@click.option('--human-time/--no-human-time', default=True,
-              help=('Accept informal descriptions such as "tomorrow" instead '
-                    'of a properly formatted date.'))
 @click.option('--colour', '--color', default=None,
               help=('By default todoman will disable colored output if stdout '
                     'is not a TTY (value `auto`). Set to `never` to disable '
@@ -82,7 +79,7 @@ _interactive_option = click.option(
               'remain stable regardless of configuration or version.')
 @click.pass_context
 @click.version_option(prog_name='todoman')
-def cli(ctx, human_time, color, porcelain):
+def cli(ctx, color, porcelain):
     try:
         config = load_config()
     except ConfigurationException as e:
@@ -93,10 +90,7 @@ def cli(ctx, human_time, color, porcelain):
     if porcelain:
         ctx.obj['formatter'] = PorcelainFormatter()
     else:
-        ctx.obj['formatter'] = TodoFormatter(
-            config['main']['date_format'],
-            human_time
-        )
+        ctx.obj['formatter'] = TodoFormatter(config['main']['date_format'])
 
     color = color or config['main']['color']
     if color == 'always':

--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -197,15 +197,13 @@ class TodoFormatter:
         "{id:3d} [{completed}] {urgent} {due} {summary} {list}{percent}"
     # compact_format = "{completed} {urgent}  {due}  {summary}"
 
-    def __init__(self, date_format, human_time):
-        self.human_time = human_time
+    def __init__(self, date_format):
         self.date_format = date_format
         self._localtimezone = tzlocal()
         self.now = datetime.now().replace(tzinfo=self._localtimezone)
         self.empty_date = " " * len(self.format_date(self.now))
 
-        if human_time:
-            self._parsedatetime_calendar = parsedatetime.Calendar()
+        self._parsedatetime_calendar = parsedatetime.Calendar()
 
     def compact(self, todo):
         """
@@ -257,23 +255,20 @@ class TodoFormatter:
             return self.empty_date
 
     def parse_date(self, date):
-        if date:
-            try:
-                rv = datetime.strptime(date, self.date_format)
-            except ValueError:
-                if not self.human_time:
-                    raise
-
-                rv, certainty = self._parsedatetime_calendar.parse(date)
-                if not certainty:
-                    raise ValueError('Time description not recognized: {}'
-                                     .format(date))
-                rv = datetime.fromtimestamp(mktime(rv))
-
-            return rv.replace(tzinfo=self._localtimezone)
-
-        else:
+        if not date:
             return None
+
+        try:
+            rv = datetime.strptime(date, self.date_format)
+        except ValueError:
+            rv, certainty = self._parsedatetime_calendar.parse(date)
+            if not certainty:
+                raise ValueError(
+                    'Time description not recognized: {}' .format(date)
+                )
+            rv = datetime.fromtimestamp(mktime(rv))
+
+        return rv.replace(tzinfo=self._localtimezone)
 
     def format_database(self, database):
         return '{}@{}'.format(database.color_ansi or '',


### PR DESCRIPTION
Always parse using human times. Scripts and integrations can use --porcelain.

PR is a lot shorter with [`?w=1`](https://github.com/pimutils/todoman/pull/99/files?w=1)

@untitaker Objections?