### PR TITLE
Fix a timing issue on a test comparison

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 flake8
 flake8-import-order
+freezegun
 hypothesis
 pytest
 pytest-cov

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ import hypothesis.strategies as st
 import pytest
 import pytz
 from dateutil.tz import tzlocal
+from freezegun import freeze_time
 from hypothesis import given
 
 from todoman.cli import cli
@@ -215,6 +216,7 @@ def test_default_due(
         )
 
 
+@freeze_time(datetime.datetime.now())
 def test_default_due2(tmpdir, runner, create, default_database):
     cfg = tmpdir.join('config')
     cfg.write('default_due = 24\n', 'a')


### PR DESCRIPTION
A single test would very infrequently fail due to a timing issue: the seconds in the current time between an instantiation and an assertion would change.

Freeze the time to avoid this.

Detected by coincidence when CI was running #99.