### PR TITLE
Add a test for python -m todoman

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,19 @@
+import os
+from subprocess import PIPE, Popen
+
+from todoman.cli import cli
+
+
+def test_main(tmpdir, runner):
+    root = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+    env = os.environ.copy()
+    env['PYTHONPATH'] = root
+
+    cli_result = runner.invoke(cli, ['--version'])
+
+    pipe = Popen(
+        ['python', '-m', 'todoman', '--version'], stdout=PIPE, env=env
+    )
+    main_output = pipe.communicate()[0]
+
+    assert cli_result.output == main_output.decode()


### PR DESCRIPTION
Test that `python -m todoman` works and runs the thing as `todo`.