### PR TITLE
Keep an eye on python 3.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7-dev
 
 env:
   matrix:
@@ -17,6 +18,8 @@ env:
     secure: IFQzIw/g6qbmZy86w9qPU5vZjoJWtBlP8VpUtBX+La9hyZ6odC0pxB38U7IQNnPKinUvnc0cGEsAJS/abxp3bSdS0H+afr8OjxOgDuLBl47fMHBxFUMF6HRFmKuk66GfM1sxf87xLdiPDF5Dac0cn7IlJrFkQaCukZjinvZRvtU=
 
 matrix:
+  allow_failures:
+    - python: 3.7-dev
   exclude:
     # Sphinx requires python 3.4 or above
     - python: 3.3


### PR DESCRIPTION
Run tests with py37-dev to keep an eye on forward compatibility, but don't fail CI if these tests fail.