### PR TITLE
Use tabulate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ icalendar
 parsedatetime
 python-dateutil
 pyxdg
+tabulate
 urwid

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -14,7 +14,7 @@ from todoman.model import Database, FileTodo
 def test_basic(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception
-    assert result.output == ''
+    assert not result.output.strip()
 
     create(
         'test.ics',
@@ -118,7 +118,7 @@ def test_delete(tmpdir, runner, create):
     assert not result.exception
     result = runner.invoke(cli, ['list'])
     assert not result.exception
-    assert len(result.output.splitlines()) == 0
+    assert not result.output.strip()
 
 
 def test_copy(tmpdir, runner, create):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -25,6 +25,29 @@ def test_basic(tmpdir, runner, create):
     assert 'harhar' in result.output
 
 
+def test_no_extra_whitespace(tmpdir, runner, create):
+    """
+    Test that we don't output extra whitespace
+
+    Test that we don't output a lot of extra whitespace when there are no
+    tasks, or when there are tasks (eg: both scenarios).
+
+    Note: Other tests should be set up so that comparisons don't care much
+    about whitespace, so that if this changes, only this test should fail.
+    """
+    result = runner.invoke(cli, ['list'], catch_exceptions=False)
+    assert not result.exception
+    assert result.output == '\n'
+
+    create(
+        'test.ics',
+        'SUMMARY:harhar\n'
+    )
+    result = runner.invoke(cli, ['list'])
+    assert not result.exception
+    assert len(result.output.splitlines()) == 1
+
+
 def test_percent(tmpdir, runner, create):
     create(
         'test.ics',

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -347,10 +347,11 @@ def test_color_due_dates(tmpdir, runner, create, hours):
     due_str = due.strftime('%Y-%m-%d')
     if hours == 72:
         assert result.output == \
-            '  1 [ ]   {} aaa @default\x1b[0m\n'.format(due_str)
+            '1  [ ]    {}  aaa @default\x1b[0m\n'.format(due_str)
     else:
         assert result.output == \
-            '  1 [ ]   \x1b[31m{}\x1b[0m aaa @default\x1b[0m\n'.format(due_str)
+            '1  [ ]    \x1b[31m{}\x1b[0m  aaa @default\x1b[0m\n' \
+            .format(due_str)
 
 
 def test_flush(tmpdir, runner, create):
@@ -370,7 +371,7 @@ def test_flush(tmpdir, runner, create):
 
     result = runner.invoke(cli, ['list'])
     assert not result.exception
-    assert '  2 [ ]              bbb @default' in result.output
+    assert '2  [ ]      bbb @default' in result.output
 
     result = runner.invoke(cli, ['flush'], input='y\n', catch_exceptions=False)
     assert not result.exception
@@ -382,7 +383,7 @@ def test_flush(tmpdir, runner, create):
 
     result = runner.invoke(cli, ['list'])
     assert not result.exception
-    assert '  1 [ ]              bbb @default' in result.output
+    assert '1  [ ]      bbb @default' in result.output
 
 
 def test_edit(runner, default_database):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,7 +38,7 @@ def test_xdg_existant(runner, tmpdir, config):
             catch_exceptions=True,
         )
         assert not result.exception
-        assert result.output == ''
+        assert not result.output.strip()
 
 
 def test_sane_config(config, runner, tmpdir):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -10,7 +10,7 @@ from todoman.model import Database, FileTodo
 def test_all(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception
-    assert result.output == ''
+    assert not result.output.strip()
 
     create(
         'one.ics',
@@ -31,7 +31,7 @@ def test_all(tmpdir, runner, create):
 def test_urgent(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception
-    assert result.output == ''
+    assert not result.output.strip()
 
     create(
         'one.ics',
@@ -51,7 +51,7 @@ def test_urgent(tmpdir, runner, create):
 def test_location(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception
-    assert result.output == ''
+    assert not result.output.strip()
 
     create(
         'one.ics',
@@ -77,7 +77,7 @@ def test_location(tmpdir, runner, create):
 def test_category(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception
-    assert result.output == ''
+    assert not result.output.strip()
 
     create(
         'one.ics',
@@ -103,7 +103,7 @@ def test_category(tmpdir, runner, create):
 def test_grep(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception
-    assert result.output == ''
+    assert not result.output.strip()
 
     create(
         'one.ics',

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -17,8 +17,8 @@ def test_human_dates():
                           12, 0)
     any_day = today + timedelta(days=randrange(2, 8))
 
-    assert formatter.format_datetime("") == "              "
-    assert formatter._format_date(today.date()) == "   Today"
+    assert formatter.format_datetime("") == ''
+    assert formatter._format_date(today.date()) == "Today"
     assert formatter._format_date(tomorrow.date()) == "Tomorrow"
     assert formatter.format_datetime(any_day) == \
         any_day.strftime(DATE_FORMAT + ' ' + TIME_FORMAT)

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -349,5 +349,4 @@ def list(
         urgent=urgent,
     )
 
-    for todo in todos:
-        click.echo(ctx.obj['formatter'].compact(todo))
+    click.echo(ctx.obj['formatter'].compact_multiple(todos))


### PR DESCRIPTION
Some testing (batches of 100 runs of `todo list`) shows that there's no real difference between this and the previous code (eg: no regressions).

The large upside is that we don't need to worry about dealing with whitespaces and aligning columns, etc in our formatter. Date/time formatting has become simpler, and its maintenance should be a lot less painful.

Also, if no todos have dates, that column will be skipped entirely.

There are some spacing changes which I'd like to avoid (I'll check a bit if they're possible to avoid or not). The changes to the tests make this obvious.

Finally, an extra empty line will get printed if there are not `todos`, which is a bit unfriendly -- though I'm thinking about replacing that with another message altogether (clarifying that you have no todos).

Closes #130 