### PR TITLE
add filter for complete/incomplete todos

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,4 +18,5 @@ Authors are listed in alphabetical order.
 * Markus Unterwaditzer <markus@unterwaditzer.net>
 * Paweł Fertyk <pfertyk@openmailbox.org>
 * Rimsha Khan <rimshakhan.rk03@gmail.com>
+* Swati Garg <swati4star@gmail.com>
 * Thomas Glanzmann <thomas@glanzmann.de>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ v2.2.0
   parameter.
 * Use the system's date format as a default.
 * Show "Today" or "Tomorrow" when due date is today/tomorrow respectively.
+* Add flag "--done-only" to todo list. Displays only completed tasks.
 
 v2.1.0
 ------

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -79,17 +79,20 @@ def test_done_only(tmpdir, runner, create):
     assert not result.exception
     assert not result.output.strip()
 
-    tmpdir.mkdir('list_one')
-    runner.invoke(cli, ['new', '-l', 'list_one', 'haha'])
-    runner.invoke(cli, ['new', '-l', 'list_one', 'hoho'])
-    runner.invoke(cli, ['new', '-l', 'list_one', 'harhar'])
-
-    runner.invoke(cli, ['list', 'done', '1'])
+    create(
+        'one.ics',
+        'SUMMARY:haha\n'
+    )
+    create(
+        'two.ics',
+        'SUMMARY:hoho\n'
+        'PERCENT-COMPLETE:100\n'
+        'STATUS:COMPLETED\n'
+    )
     result = runner.invoke(cli, ['list', '--done-only'])
     assert not result.exception
-    assert 'haha' in result.output
-    assert 'hoho' not in result.output
-    assert 'harhar' not in result.output
+    assert 'haha' not in result.output
+    assert 'hoho' in result.output
 
 
 def test_category(tmpdir, runner, create):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -74,6 +74,24 @@ def test_location(tmpdir, runner, create):
     assert 'harhar' not in result.output
 
 
+def test_done_only(tmpdir, runner, create):
+    result = runner.invoke(cli, ['list'], catch_exceptions=False)
+    assert not result.exception
+    assert not result.output.strip()
+
+    tmpdir.mkdir('list_one')
+    runner.invoke(cli, ['new', '-l', 'list_one', 'haha'])
+    runner.invoke(cli, ['new', '-l', 'list_one', 'hoho'])
+    runner.invoke(cli, ['new', '-l', 'list_one', 'harhar'])
+
+    runner.invoke(cli, ['list', 'done', '1'])
+    result = runner.invoke(cli, ['list', '--done-only'])
+    assert not result.exception
+    assert 'haha' in result.output
+    assert 'hoho' not in result.output
+    assert 'harhar' not in result.output
+
+
 def test_category(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -41,6 +41,17 @@ def _validate_list_param(ctx, param=None, name=None):
         )
 
 
+def _validate_filter_param(ctx, param, val):
+    if val is None:
+        return False
+    if 'completed' == val or 'complete' == val:
+        return True
+    if 'incomplete' == val:
+        return False
+    raise click.BadParameter("Ivalid value for filter. Available options are"
+                             " complete, incomplete")
+
+
 def _validate_date_param(ctx, param, val):
     try:
         return ctx.obj['formatter'].parse_datetime(val)
@@ -317,8 +328,11 @@ def move(ctx, list, ids):
               'Defaults to true.')
 @click.option('--due', default=None, help='Only show tasks due in DUE hours',
               type=int)
+@click.option('--filter', default=None, callback=_validate_filter_param,
+              help='Only show complete/incomplete tasks')
 def list(
     ctx, lists, all, urgent, location, category, grep, sort, reverse, due,
+    filter
          ):
     """
     List unfinished tasks.
@@ -347,6 +361,7 @@ def list(
         reverse=reverse,
         sort=sort,
         urgent=urgent,
+        complete=filter,
     )
 
     click.echo(ctx.obj['formatter'].compact_multiple(todos))

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -41,17 +41,6 @@ def _validate_list_param(ctx, param=None, name=None):
         )
 
 
-def _validate_filter_param(ctx, param, val):
-    if val is None:
-        return False
-    if 'completed' == val or 'complete' == val:
-        return True
-    if 'incomplete' == val:
-        return False
-    raise click.BadParameter("Ivalid value for filter. Available options are"
-                             " complete, incomplete")
-
-
 def _validate_date_param(ctx, param, val):
     try:
         return ctx.obj['formatter'].parse_datetime(val)
@@ -328,11 +317,11 @@ def move(ctx, list, ids):
               'Defaults to true.')
 @click.option('--due', default=None, help='Only show tasks due in DUE hours',
               type=int)
-@click.option('--filter', default=None, callback=_validate_filter_param,
-              help='Only show complete/incomplete tasks')
+@click.option('--done-only', default=False, is_flag=True,
+              help='Only show finished tasks')
 def list(
     ctx, lists, all, urgent, location, category, grep, sort, reverse, due,
-    filter
+    done_only
          ):
     """
     List unfinished tasks.
@@ -361,7 +350,7 @@ def list(
         reverse=reverse,
         sort=sort,
         urgent=urgent,
-        complete=filter,
+        complete=done_only,
     )
 
     click.echo(ctx.obj['formatter'].compact_multiple(todos))

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -581,8 +581,7 @@ class Cache:
         if not all:
             # XXX: Duplicated logic of Todo.is_completed
             if complete:
-                extra_where.append('AND status != "CANCELLED" '
-                                   'AND status == "COMPLETED"')
+                extra_where.append('AND status == "COMPLETED"')
             else:
                 extra_where.append('AND completed_at is NULL '
                                    'AND status != "CANCELLED" '

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -544,7 +544,8 @@ class Cache:
         return rv
 
     def todos(self, all=False, lists=[], urgent=False, location='',
-              category='', grep='', sort=[], reverse=True, due=None):
+              category='', grep='', sort=[], reverse=True, due=None,
+              complete=None):
         """
         Returns filtered cached todos, in a specified order.
 
@@ -567,6 +568,8 @@ class Cache:
             with a ``-`` prepended will be used to sort in reverse order.
         :param bool reverse: Reverse the order of the todos after sorting.
         :param int due: Return only todos due within ``due`` hours.
+        :param bool complete: If true, return completed tasks,
+            else incomplete tasks
         :return: A sorted, filtered list of todos.
         :rtype: generator
         """
@@ -577,9 +580,13 @@ class Cache:
 
         if not all:
             # XXX: Duplicated logic of Todo.is_completed
-            extra_where.append('AND completed_at is NULL '
-                               'AND status != "CANCELLED" '
-                               'AND status != "COMPLETED"')
+            if complete:
+                extra_where.append('AND status != "CANCELLED" '
+                                   'AND status == "COMPLETED"')
+            else:
+                extra_where.append('AND completed_at is NULL '
+                                   'AND status != "CANCELLED" '
+                                   'AND status != "COMPLETED"')
         if lists:
             lists = [l.name if isinstance(l, List) else l for l in lists]
             q = ', '.join(['?'] * len(lists))


### PR DESCRIPTION
Option to add 
`filter="complete"`
`filter="incomplete"`
to todo list

Another enhancement as mentioned in https://github.com/pimutils/todoman/issues/18

Example:

```
 todo list --filter="complete"
6  [X]    2017-02-22 07:21:35  HELLO @Personal (100%)
1  [X]    2017-02-22 05:35:56  HELLO @Personal (100%)

todo list --filter="incomplete"
 8  [ ]    2017-06-22             long task @Personal
 9  [ ]    Today 02:40:45         my @Personal
 7  [ ]    2017-02-22 11:08:17    hello task 2 @Personal
 5  [ ]    2017-02-22 10:49:22    do something @Personal
 4  [ ]    2017-02-22 10:48:54    Task 3 @Personal
 3  [ ]    2017-02-22 07:21:37    HELLO @Personal

```