### PR TITLE
Add new dependency (tabulate) to the changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ releases, in reverse chronological order.
 v2.2.0
 ------
 
+* New PyPI dependency ``tabulate``.
 * Basic support for times in due dates, new ``time_format`` configuration
   parameter.
 * Use the system's date format as a default.


### PR DESCRIPTION
Kind of missed the changelog since there are no user-facing changes, but there ARE packager-facing changes.