### PR TITLE
Correction in priority filtering test

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -81,8 +81,7 @@ def test_priority(tmpdir, runner, create):
     assert 'hoho' in result_none.output
     assert 'huhu' in result_none.output
 
-    result_error = runner.invoke(cli, ['--porcelain', 'list',
-                                 '--priority=blah'])
+    result_error = runner.invoke(cli, ['list', '--priority=blah'])
     assert result_error.exception
 
 


### PR DESCRIPTION
Removed `--porcelain` from filtering tests.
r? @hobarrera @untitaker 