### PR TITLE
Proper porcelain json

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ v3.0.0
 * Add flag "--done-only" to todo list. Displays only completed tasks.
 * Make the output of move, delete, copy and flush more consistent with
   everything else.
+* Porcelain now outputs proper JSON, rather than one-JSON-per-line.
 
 
 v2.1.0

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -66,7 +66,8 @@ output, you're advised to use the ``--porcelain`` flag, which will print all
 output in a pre-defined format that will remain stable regardless of user
 configuration or version.
 
-The format is JSON, with one todo per line. Fields will always be present; if a
-todo does not have a value for a given field, it will be printed as ``null``.
+The format is JSON, with a single array containing each todo as a single entry
+(object). Fields will always be present; if a todo does not have a value for a
+given field, it will be printed as ``null``.
 
 Fields MAY be added in future, but will never be removed.

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -13,7 +13,7 @@ def test_list_all(tmpdir, runner, create):
     )
     result = runner.invoke(cli, ['--porcelain', 'list', '--all'])
 
-    expected = {
+    expected = [{
         'completed': True,
         'due': 1451689200,
         'id': 1,
@@ -21,7 +21,7 @@ def test_list_all(tmpdir, runner, create):
         'percent': 26,
         'priority': 0,
         'summary': 'Do stuff',
-    }
+    }]
 
     assert not result.exception
     assert result.output.strip() == json.dumps(expected, sort_keys=True)
@@ -36,7 +36,7 @@ def test_list_nodue(tmpdir, runner, create):
     )
     result = runner.invoke(cli, ['--porcelain', 'list'])
 
-    expected = {
+    expected = [{
         'completed': False,
         'due': None,
         'id': 1,
@@ -44,7 +44,7 @@ def test_list_nodue(tmpdir, runner, create):
         'percent': 12,
         'priority': 4,
         'summary': 'Do stuff',
-    }
+    }]
 
     assert not result.exception
     assert result.output.strip() == json.dumps(expected, sort_keys=True)
@@ -54,7 +54,7 @@ def test_list_priority(tmpdir, runner, create):
     result = runner.invoke(cli, ['--porcelain', 'list'],
                            catch_exceptions=False)
     assert not result.exception
-    assert not result.output.strip()
+    assert result.output.strip() == '[]'
     create(
         'one.ics',
         'SUMMARY:haha\n'

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -1,3 +1,5 @@
+import json
+
 from todoman.cli import cli
 
 
@@ -9,14 +11,20 @@ def test_list_all(tmpdir, runner, create):
         'DUE;VALUE=DATE-TIME;TZID=CET:20160102T000000\n'
         'PERCENT-COMPLETE:26\n'
     )
-
     result = runner.invoke(cli, ['--porcelain', 'list', '--all'])
+
+    expected = {
+        'completed': True,
+        'due': 1451689200,
+        'id': 1,
+        'list': 'default',
+        'percent': 26,
+        'priority': 0,
+        'summary': 'Do stuff',
+    }
+
     assert not result.exception
-    assert (
-        result.output.strip() ==
-        '{"completed": true, "due": 1451689200, "id": 1, "list": "default'
-        '", "percent": 26, "priority": 0, "summary": "Do stuff"}'
-    )
+    assert result.output.strip() == json.dumps(expected, sort_keys=True)
 
 
 def test_list_nodue(tmpdir, runner, create):
@@ -26,14 +34,20 @@ def test_list_nodue(tmpdir, runner, create):
         'PERCENT-COMPLETE:12\n'
         'PRIORITY:4\n'
     )
-
     result = runner.invoke(cli, ['--porcelain', 'list'])
+
+    expected = {
+        'completed': False,
+        'due': None,
+        'id': 1,
+        'list': 'default',
+        'percent': 12,
+        'priority': 4,
+        'summary': 'Do stuff',
+    }
+
     assert not result.exception
-    assert (
-        result.output.strip() ==
-        '{"completed": false, "due": null, "id": 1, "list": "default'
-        '", "percent": 12, "priority": 4, "summary": "Do stuff"}'
-    )
+    assert result.output.strip() == json.dumps(expected, sort_keys=True)
 
 
 def test_list_priority(tmpdir, runner, create):
@@ -106,8 +120,16 @@ def test_show(tmpdir, runner, create):
         'PRIORITY:5\n'
     )
     result = runner.invoke(cli, ['--porcelain', 'show', '1'])
+
+    expected = {
+        'completed': False,
+        'due': None,
+        'id': 1,
+        'list': 'default',
+        'percent': 0,
+        'priority': 5,
+        'summary': 'harhar',
+    }
+
     assert not result.exception
-    assert (
-        result.output == '{"completed": false, "due": null, "id": 1, "list": '
-        '"default", "percent": 0, "priority": 5, "summary": "harhar"}\n'
-    )
+    assert result.output.strip() == json.dumps(expected, sort_keys=True)

--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -374,8 +374,8 @@ class TodoFormatter:
 
 class PorcelainFormatter:
 
-    def compact(self, todo):
-        data = dict(
+    def _todo_as_dict(self, todo):
+        return dict(
             completed=todo.is_completed,
             due=self.format_datetime(todo.due),
             id=todo.id,
@@ -385,6 +385,11 @@ class PorcelainFormatter:
             priority=todo.priority,
         )
 
+    def compact(self, todo):
+        return json.dumps(self._todo_as_dict(todo), sort_keys=True)
+
+    def compact_multiple(self, todos):
+        data = [self._todo_as_dict(todo) for todo in todos]
         return json.dumps(data, sort_keys=True)
 
     def simple_action(self, action, todo):
@@ -400,13 +405,6 @@ class PorcelainFormatter:
                 raise ValueError('Priority has to be in the range 0-9')
         except ValueError as e:
             raise click.BadParameter(e)
-
-    def compact_multiple(self, todos):
-        data = []
-        for todo in todos:
-            data.append(self.compact(todo))
-
-        return '\n'.join(data)
 
     def detailed(self, todo):
         return self.compact(todo)


### PR DESCRIPTION
Make tests simpler, and output proper JSON.

Since the next release will alter porcelain, let's go the whole way (also, this makes using `jq` or other stuff less painful).