### PR TITLE
Stop using custom formatting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ v3.0.0
 * Add ``--start="[before|after] <date>`` option for ``todo list``. It shows todos
   created before/after given date.
 * Add flag "--done-only" to todo list. Displays only completed tasks.
+* Make the output of move, delete, copy and flush more consistent with
+  everything else.
 
 
 v2.1.0

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -276,7 +276,7 @@ def flush(ctx):
     '''
     database = ctx.obj['db']
     for todo in database.flush():
-        click.echo('Deleting {} ({})'.format(todo.uid, todo.summary))
+        click.echo(ctx.obj['formatter'].simple_action('Flushing', todo))
 
 
 @cli.command()
@@ -296,7 +296,7 @@ def delete(ctx, ids, yes):
         click.confirm('Do you want to delete those tasks?', abort=True)
 
     for todo in todos:
-        click.echo('Deleting {} ({})'.format(todo.uid, todo.summary))
+        click.echo(ctx.obj['formatter'].simple_action('Deleting', todo))
         ctx.obj['db'].delete(todo)
 
 
@@ -310,9 +310,7 @@ def copy(ctx, list, ids):
 
     for id in ids:
         todo = ctx.obj['db'].todo(id)
-        click.echo('Copying {} to {} ({})'.format(
-            todo.uid, list, todo.summary
-        ))
+        click.echo(ctx.obj['formatter'].compact(todo))
 
         ctx.obj['db'].save(todo, list)
 
@@ -327,9 +325,7 @@ def move(ctx, list, ids):
 
     for id in ids:
         todo = ctx.obj['db'].todo(id)
-        click.echo('Moving {} to {} ({})'.format(
-            todo.uid, list, todo.summary
-        ))
+        click.echo(ctx.obj['formatter'].compact(todo))
 
         ctx.obj['db'].move(todo, list)
 

--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -230,6 +230,9 @@ class TodoFormatter:
         }
         self._parsedatetime_calendar = parsedatetime.Calendar()
 
+    def simple_action(self, action, todo):
+        return '{} "{}"'.format(action, todo.summary)
+
     def compact(self, todo):
         return self.compact_multiple([todo])
 
@@ -383,6 +386,9 @@ class PorcelainFormatter:
         )
 
         return json.dumps(data, sort_keys=True)
+
+    def simple_action(self, action, todo):
+        return self.compact(todo)
 
     def parse_priority(self, priority):
         if priority is None:


### PR DESCRIPTION
We had some custom formatting in `cli`. Get rid for that:

1. For consistency.
2. Because this lets us porcelenate stuff.
3. Printing UUIDs to the end-user is not helpful.