### PR TITLE
prettify porcelain formatter

### DIFF
--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -24,7 +24,8 @@ def test_list_all(tmpdir, runner, create):
     }]
 
     assert not result.exception
-    assert result.output.strip() == json.dumps(expected, sort_keys=True)
+    assert result.output.strip() == json.dumps(expected, indent=4,
+                                               sort_keys=True)
 
 
 def test_list_nodue(tmpdir, runner, create):
@@ -47,7 +48,8 @@ def test_list_nodue(tmpdir, runner, create):
     }]
 
     assert not result.exception
-    assert result.output.strip() == json.dumps(expected, sort_keys=True)
+    assert result.output.strip() == json.dumps(expected, indent=4,
+                                               sort_keys=True)
 
 
 def test_list_priority(tmpdir, runner, create):
@@ -132,4 +134,5 @@ def test_show(tmpdir, runner, create):
     }
 
     assert not result.exception
-    assert result.output.strip() == json.dumps(expected, sort_keys=True)
+    assert result.output.strip() == json.dumps(expected, indent=4,
+                                               sort_keys=True)

--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -386,11 +386,11 @@ class PorcelainFormatter:
         )
 
     def compact(self, todo):
-        return json.dumps(self._todo_as_dict(todo), sort_keys=True)
+        return json.dumps(self._todo_as_dict(todo), indent=4, sort_keys=True)
 
     def compact_multiple(self, todos):
         data = [self._todo_as_dict(todo) for todo in todos]
-        return json.dumps(data, sort_keys=True)
+        return json.dumps(data, indent=4, sort_keys=True)
 
     def simple_action(self, action, todo):
         return self.compact(todo)


### PR DESCRIPTION
Right now, in porcelain formatter, the output is displayed in single line, not easy to understand.
This makes the output like this,

```
[
    {
        "completed": false,
        "due": 1498069800,
        "id": 8,
        "list": "Personal",
        "percent": 0,
        "priority": 0,
        "summary": "long task"
    },
    {
        "completed": false,
        "due": 1488263036,
        "id": 15,
        "list": "Personal",
        "percent": 0,
        "priority": 0,
        "summary": "doing"
    }
]
```  