### PR TITLE
Introduce AppContext, lazy init for formatters

### DIFF
--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -171,7 +171,7 @@ def cli(click_ctx, color, porcelain):
     if len(paths) == 0:
         click.echo("No lists found matching {}, "
                    "create a directory for a new list"
-                   .format(config["main"]["path"]))
+                   .format(ctx.config["main"]["path"]))
         ctx.exit(1)
 
     ctx.db = Database(paths, ctx.config['main']['cache_path'])
@@ -285,8 +285,7 @@ def done(ctx, ids):
     Mark a task as done.
     '''
     for id in ids:
-        database = ctx.db
-        todo = database.todo(id)
+        todo = ctx.db.todo(id)
         todo.is_completed = True
         todo.save()
         click.echo(ctx.formatter.detailed(todo))

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -1,6 +1,7 @@
 import functools
 import glob
 import locale
+import sys
 from datetime import timedelta
 from os.path import expanduser, isdir
 
@@ -9,7 +10,7 @@ import click_log
 
 from . import model
 from .configuration import ConfigurationException, load_config
-from .model import Database, FileTodo
+from .model import cached_property, Database, FileTodo
 from .ui import EditState, PorcelainFormatter, TodoEditor, TodoFormatter
 
 TODO_ID_MIN = 1
@@ -22,19 +23,20 @@ def _validate_lists_param(ctx, param=None, lists=None):
 
 
 def _validate_list_param(ctx, param=None, name=None):
+    ctx = ctx.find_object(AppContext)
     if name is None:
-        if 'default_list' in ctx.obj['config']['main']:
-            name = ctx.obj['config']['main']['default_list']
+        if 'default_list' in ctx.config['main']:
+            name = ctx.config['main']['default_list']
         else:
             raise click.BadParameter(
                 "{}. You must set 'default_list' or use -l."
                 .format(name)
             )
-    for l in ctx.obj['db'].lists():
+    for l in ctx.db.lists():
         if l.name == name:
             return l
     else:
-        list_names = [l.name for l in ctx.obj['db'].lists()]
+        list_names = [l.name for l in ctx.db.lists()]
         raise click.BadParameter(
             "{}. Available lists are: {}"
             .format(name, ', '.join(list_names))
@@ -42,20 +44,23 @@ def _validate_list_param(ctx, param=None, name=None):
 
 
 def _validate_date_param(ctx, param, val):
+    ctx = ctx.find_object(AppContext)
     try:
-        return ctx.obj['formatter'].parse_datetime(val)
+        return ctx.formatter.parse_datetime(val)
     except ValueError as e:
         raise click.BadParameter(e)
 
 
 def _validate_priority_param(ctx, param, val):
+    ctx = ctx.find_object(AppContext)
     try:
-        return ctx.obj['formatter'].parse_priority(val)
+        return ctx.formatter.parse_priority(val)
     except ValueError as e:
         raise click.BadParameter(e)
 
 
 def _validate_start_date_param(ctx, param, val):
+    ctx = ctx.find_object(AppContext)
     if val is None:
         return val
     if val.startswith('before '):
@@ -69,7 +74,7 @@ def _validate_start_date_param(ctx, param, val):
             "The start date of the task should be"
             "in format '[before|after] <date-format>'")
     try:
-        dt = ctx.obj['formatter'].parse_datetime(val)
+        dt = ctx.formatter.parse_datetime(val)
         return is_before, dt
     except ValueError as e:
         raise click.BadParameter(e)
@@ -97,6 +102,35 @@ def _todo_property_options(command):
     return command_wrap
 
 
+class AppContext:
+    def __init__(self):
+        self.config = None
+        self.db = None
+        self.porcelain = False
+
+    @cached_property
+    def ui_formatter(self):
+        return TodoFormatter(
+            self.config['main']['date_format'],
+            self.config['main']['time_format'],
+            self.config['main']['dt_separator']
+        )
+
+    @cached_property
+    def porcelain_formatter(self):
+        return PorcelainFormatter()
+
+    @cached_property
+    def formatter(self):
+        if self.porcelain:
+            return self.porcelain_formatter
+        else:
+            return self.ui_formatter
+
+
+pass_ctx = click.make_pass_decorator(AppContext)
+
+
 _interactive_option = click.option(
     '--interactive', '-i', is_flag=True, default=None,
     help='Go into interactive mode before saving the task.')
@@ -115,33 +149,23 @@ _interactive_option = click.option(
               'remain stable regardless of configuration or version.')
 @click.pass_context
 @click.version_option(prog_name='todoman')
-def cli(ctx, color, porcelain):
+def cli(click_ctx, color, porcelain):
+    ctx = click_ctx.ensure_object(AppContext)
     try:
-        config = load_config()
+        ctx.config = load_config()
     except ConfigurationException as e:
         raise click.ClickException(e.args[0])
 
-    ctx.obj = {
-        'config': config,
-    }
-
-    if porcelain:
-        ctx.obj['formatter'] = PorcelainFormatter()
-    else:
-        ctx.obj['formatter'] = TodoFormatter(
-            config['main']['date_format'],
-            config['main']['time_format'],
-            config['main']['dt_separator'],
-        )
-
-    color = color or config['main']['color']
+    color = color or ctx.config['main']['color']
     if color == 'always':
-        ctx.color = True
+        click_ctx.color = True
     elif color == 'never':
-        ctx.color = False
+        click_ctx.color = False
+
+    ctx.porcelain = porcelain
 
     paths = [
-        path for path in glob.iglob(expanduser(config["main"]["path"]))
+        path for path in glob.iglob(expanduser(ctx.config["main"]["path"]))
         if isdir(path)
     ]
     if len(paths) == 0:
@@ -150,10 +174,10 @@ def cli(ctx, color, porcelain):
                    .format(config["main"]["path"]))
         ctx.exit(1)
 
-    ctx.obj['db'] = Database(paths, config['main']['cache_path'])
+    ctx.db = Database(paths, ctx.config['main']['cache_path'])
 
-    if not ctx.invoked_subcommand:
-        ctx.invoke(cli.commands["list"])
+    if not click_ctx.invoked_subcommand:
+        click_ctx.invoke(cli.commands["list"])
 
     # Make python actually use LC_TIME, or the user's locale settings
     locale.setlocale(locale.LC_TIME, "")
@@ -173,7 +197,7 @@ except ImportError:
               help='The list to create the task in.')
 @_todo_property_options
 @_interactive_option
-@click.pass_context
+@pass_ctx
 def new(ctx, summary, list, todo_properties, interactive):
     '''
     Create a new task with SUMMARY.
@@ -181,7 +205,7 @@ def new(ctx, summary, list, todo_properties, interactive):
 
     todo = FileTodo()
 
-    default_due = ctx.obj['config']['main']['default_due']
+    default_due = ctx.config['main']['default_due']
     if default_due:
         todo.due = todo.created_at + timedelta(hours=default_due)
 
@@ -191,21 +215,21 @@ def new(ctx, summary, list, todo_properties, interactive):
     todo.summary = ' '.join(summary)
 
     if interactive or (not summary and interactive is None):
-        ui = TodoEditor(todo, ctx.obj['db'].lists(), ctx.obj['formatter'])
+        ui = TodoEditor(todo, ctx.db.lists(), ctx.formatter)
         if ui.edit() != EditState.saved:
-            ctx.exit(1)
+            sys.exit(1)
         click.echo()  # work around lines going missing after urwid
 
     if not todo.summary:
         raise click.UsageError('No SUMMARY specified')
 
     todo.list = list
-    ctx.obj['db'].save(todo, list)
-    click.echo(ctx.obj['formatter'].detailed(todo))
+    ctx.db.save(todo, list)
+    click.echo(ctx.formatter.detailed(todo))
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @_todo_property_options
 @_interactive_option
 @with_id_arg
@@ -213,8 +237,7 @@ def edit(ctx, id, todo_properties, interactive):
     '''
     Edit the task with id ID.
     '''
-    database = ctx.obj['db']
-    todo = database.todo(id)
+    todo = ctx.db.todo(id)
     old_list = todo.list
 
     changes = False
@@ -224,7 +247,7 @@ def edit(ctx, id, todo_properties, interactive):
             setattr(todo, key, value)
 
     if interactive or (not changes and interactive is None):
-        ui = TodoEditor(todo, ctx.obj['db'].lists(), ctx.obj['formatter'])
+        ui = TodoEditor(todo, ctx.db.lists(), ctx.ui_formatter)
         state = ui.edit()
         if state == EditState.saved:
             changes = True
@@ -232,41 +255,41 @@ def edit(ctx, id, todo_properties, interactive):
     if changes:
         todo.save()
         if old_list.name != todo.list.name:
-            database.move(todo, todo.list, from_list=old_list)
-        click.echo(ctx.obj['formatter'].detailed(todo))
+            ctx.db.move(todo, todo.list, from_list=old_list)
+        click.echo(ctx.formatter.detailed(todo))
     else:
         click.echo('No changes.')
-        ctx.exit(1)
+        sys.exit(1)
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @with_id_arg
 def show(ctx, id):
     '''
     Show details about a task.
     '''
     try:
-        todo = ctx.obj['db'].todo(id)
-        click.echo(ctx.obj['formatter'].detailed(todo))
+        todo = ctx.db.todo(id)
+        click.echo(ctx.formatter.detailed(todo))
     except model.NoSuchTodo:
         click.echo("No todo with id {}.".format(id))
-        ctx.exit(-2)
+        sys.exit(-2)
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @click.argument('ids', nargs=-1, required=True, type=click.IntRange(0))
 def done(ctx, ids):
     '''
     Mark a task as done.
     '''
     for id in ids:
-        database = ctx.obj['db']
+        database = ctx.db
         todo = database.todo(id)
         todo.is_completed = True
         todo.save()
-        click.echo(ctx.obj['formatter'].detailed(todo))
+        click.echo(ctx.formatter.detailed(todo))
 
 
 def _abort_if_false(ctx, param, value):
@@ -275,7 +298,7 @@ def _abort_if_false(ctx, param, value):
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @click.confirmation_option(
     prompt='Are you sure you want to delete all done tasks?'
 )
@@ -283,13 +306,13 @@ def flush(ctx):
     '''
     Delete done tasks. This will also clear the cache to reset task IDs.
     '''
-    database = ctx.obj['db']
+    database = ctx.db
     for todo in database.flush():
         click.echo(ctx.obj['formatter'].simple_action('Flushing', todo))
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @click.argument('ids', nargs=-1, required=True, type=click.IntRange(0))
 @click.option('--yes', is_flag=True, default=False)
 def delete(ctx, ids, yes):
@@ -297,20 +320,20 @@ def delete(ctx, ids, yes):
 
     todos = []
     for i in ids:
-        todo = ctx.obj['db'].todo(i)
-        click.echo(ctx.obj['formatter'].compact(todo))
+        todo = ctx.db.todo(i)
+        click.echo(ctx.formatter.compact(todo))
         todos.append(todo)
 
     if not yes:
         click.confirm('Do you want to delete those tasks?', abort=True)
 
     for todo in todos:
-        click.echo(ctx.obj['formatter'].simple_action('Deleting', todo))
-        ctx.obj['db'].delete(todo)
+        click.echo(ctx.formatter.simple_action('Deleting', todo))
+        ctx.db.delete(todo)
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @click.option('--list', '-l', callback=_validate_list_param,
               help='The list to copy the tasks to.')
 @click.argument('ids', nargs=-1, required=True, type=click.IntRange(0))
@@ -318,14 +341,13 @@ def copy(ctx, list, ids):
     '''Copy tasks to another list.'''
 
     for id in ids:
-        todo = ctx.obj['db'].todo(id)
-        click.echo(ctx.obj['formatter'].compact(todo))
-
-        ctx.obj['db'].save(todo, list)
+        todo = ctx.db.todo(id)
+        click.echo(ctx.formatter.compact(todo))
+        ctx.db.save(todo, list)
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @click.option('--list', '-l', callback=_validate_list_param,
               help='The list to move the tasks to.')
 @click.argument('ids', nargs=-1, required=True, type=click.IntRange(0))
@@ -333,14 +355,13 @@ def move(ctx, list, ids):
     '''Move tasks to another list.'''
 
     for id in ids:
-        todo = ctx.obj['db'].todo(id)
-        click.echo(ctx.obj['formatter'].compact(todo))
-
-        ctx.obj['db'].move(todo, list)
+        todo = ctx.db.todo(id)
+        click.echo(ctx.formatter.compact(todo))
+        ctx.db.move(todo, list)
 
 
 @cli.command()
-@click.pass_context
+@pass_ctx
 @click.option('--all', '-a', is_flag=True, help='Also show finished tasks.')
 @click.argument('lists', nargs=-1, callback=_validate_lists_param)
 @click.option('--location', help='Only show tasks with location containg TEXT')
@@ -375,5 +396,5 @@ def list(ctx, **kwargs):
     This is the default action when running `todo'.
     """
 
-    todos = ctx.obj['db'].todos(**kwargs)
-    click.echo(ctx.obj['formatter'].compact_multiple(todos))
+    todos = ctx.db.todos(**kwargs)
+    click.echo(ctx.formatter.compact_multiple(todos))

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -307,7 +307,7 @@ def flush(ctx):
     '''
     database = ctx.db
     for todo in database.flush():
-        click.echo(ctx.obj['formatter'].simple_action('Flushing', todo))
+        click.echo(ctx.formatter.simple_action('Flushing', todo))
 
 
 @cli.command()

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -215,7 +215,7 @@ def new(ctx, summary, list, todo_properties, interactive):
     todo.summary = ' '.join(summary)
 
     if interactive or (not summary and interactive is None):
-        ui = TodoEditor(todo, ctx.db.lists(), ctx.formatter)
+        ui = TodoEditor(todo, ctx.db.lists(), ctx.ui_formatter)
         if ui.edit() != EditState.saved:
             sys.exit(1)
         click.echo()  # work around lines going missing after urwid

--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -40,18 +40,18 @@ class TodoEditor:
         self._msg_text = urwid.Text('')
         if todo.due:
             # TODO: use proper date_format
-            due = formatter.format_datetime(todo.due)
+            due = formatter.format_datetime(todo.due, humanize=False)
         else:
             due = ""
 
         if todo.start:
             # TODO: use proper date_format
-            dtstart = formatter.format_datetime(todo.start)
+            dtstart = formatter.format_datetime(todo.start, humanize=False)
         else:
             dtstart = ''
 
         if todo.priority:
-            priority = formatter.parse_priority(todo.priority)
+            priority = formatter.parse_priority(todo.priority, humanize=False)
         else:
             priority = ''
 
@@ -281,7 +281,7 @@ class TodoFormatter:
             rv = "{}\n\n{}".format(rv, todo.description)
         return rv
 
-    def _format_date(self, date):
+    def _format_date(self, date, humanize=True):
         """
         Format the date using ``date_format``
 
@@ -293,7 +293,7 @@ class TodoFormatter:
         :param datetime.date date: a date object
         """
         if date:
-            if date in self.special_dates:
+            if humanize and date in self.special_dates:
                 rv = self.special_dates[date]
             else:
                 rv = date.strftime(self.date_format)
@@ -307,7 +307,7 @@ class TodoFormatter:
         else:
             return ''
 
-    def format_datetime(self, dt):
+    def format_datetime(self, dt, humanize=True):
         if not dt:
             date_part = None
             time_part = None
@@ -317,7 +317,7 @@ class TodoFormatter:
             time_part = dt.time()
 
         return self.dt_separator.join(filter(bool, (
-            self._format_date(date_part),
+            self._format_date(date_part, humanize=humanize),
             self._format_time(time_part)
         )))
 


### PR DESCRIPTION
Fix #158

Doesn't do anything against #159, because that only crashes because
PorcelainFormatter has no `parse_datetime` method. Could we fix this by having
`PorcelainFormatter` subclass `TodoFormatter`? Whatever we do there, we should find a way to ensure `PorcelainFormatter` and `TodoFormatter` have the same methods. Sounds like a job for ABCs, but those have runtime overhead.