### PR TITLE
Improve test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,11 +71,18 @@ def now_for_tz():
 
 @pytest.fixture
 def todo_factory(default_database):
-    def inner(priority=None):
+    def inner(
+            due=None,
+            priority=None,
+            summary='YARR!',
+              ):
         todo = model.FileTodo()
         todo.list = list(default_database.lists())[0]
-        todo.summary = 'YARR!'
+
+        todo.due = due
         todo.priority = priority
+        todo.summary = summary
+
         todo.save()
 
         return todo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -466,5 +466,29 @@ def test_location(runner):
     assert 'Chembur' in result.output
 
 
-# TODO: test aware/naive datetime sorting
+def test_sort_mixed_timezones(runner, create):
+    """
+    Test sorting mixed timezones.
+
+    The times on this tests are carefully chosen so that a TZ-naive comparison
+    gives the opposite results.
+    """
+    create(
+        'test.ics',
+        'SUMMARY:first\n'
+        'DUE;VALUE=DATE-TIME;TZID=CET:20170304T180000\n'  # 1700 UTC
+    )
+    create(
+        'test2.ics',
+        'SUMMARY:second\n'
+        'DUE;VALUE=DATE-TIME;TZID=HST:20170304T080000\n'  # 1800 UTC
+    )
+
+    result = runner.invoke(cli, ['list', '--all'])
+    assert not result.exception
+    output = result.output.strip()
+    assert len(output.splitlines()) == 2
+    assert 'second' in result.output.splitlines()[0]
+    assert 'first' in result.output.splitlines()[1]
+
 # TODO: test --grep

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,14 @@ def test_list(tmpdir, runner, create):
     assert 'harhar' in result.output
 
 
+def test_no_default_list(runner):
+    result = runner.invoke(cli, ['new', 'Configure a default list'])
+
+    assert result.exception
+    assert ('Error: Invalid value for "--list" / "-l": You must set '
+            '"default_list" or use -l.' in result.output)
+
+
 def test_no_extra_whitespace(tmpdir, runner, create):
     """
     Test that we don't output extra whitespace

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from todoman.cli import cli
 from todoman.model import Database, FileTodo
 
 
-def test_basic(tmpdir, runner, create):
+def test_list(tmpdir, runner, create):
     result = runner.invoke(cli, ['list'], catch_exceptions=False)
     assert not result.exception
     assert not result.output.strip()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -24,3 +24,27 @@ def test_human_dates():
         any_day.strftime(DATE_FORMAT + ' ' + TIME_FORMAT)
     assert formatter.format_datetime(tomorrow_12am) == "Tomorrow 12:00"
     assert formatter.parse_datetime('12:00').replace(tzinfo=None) == today_12am
+
+
+def test_format_priority():
+    formatter = ui.TodoFormatter('', '', '')
+
+    assert formatter.format_priority(None) == ''
+    assert formatter.format_priority(0) == ''
+    assert formatter.format_priority(5) == 'medium'
+    for i in range(1, 5):
+        assert formatter.format_priority(i) == 'high'
+    for i in range(6, 10):
+        assert formatter.format_priority(i) == 'low'
+
+
+def test_format_priority_compact():
+    formatter = ui.TodoFormatter('', '', '')
+
+    assert formatter.format_priority_compact(None) == ''
+    assert formatter.format_priority_compact(0) == ''
+    assert formatter.format_priority_compact(5) == '!!'
+    for i in range(1, 5):
+        assert formatter.format_priority_compact(i) == '!!!'
+    for i in range(6, 10):
+        assert formatter.format_priority_compact(i) == '!'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -96,3 +96,39 @@ def test_sequence_increment(tmpdir):
                  if component.name == "VTODO"]
 
     assert sequence == 2
+
+
+def test_list_displayname(tmpdir):
+    tmpdir.join('default').mkdir()
+    with tmpdir.join('default').join('displayname').open('w') as f:
+        f.write('personal')
+
+    db = Database([tmpdir.join('default')], tmpdir.join('cache.sqlite3'))
+    list_ = next(db.lists())
+
+    assert list_.name == 'personal'
+    assert str(list_) == 'personal'
+
+
+def test_list_colour(tmpdir):
+    tmpdir.join('default').mkdir()
+    with tmpdir.join('default').join('color').open('w') as f:
+        f.write('#8ab6d2')
+
+    db = Database([tmpdir.join('default')], tmpdir.join('cache.sqlite3'))
+    list_ = next(db.lists())
+
+    assert list_.color_raw == '#8ab6d2'
+    assert list_.color_rgb == (138, 182, 210)
+    assert list_.color_ansi == '\x1b[38;2;138;182;210m'
+
+
+def test_list_no_colour(tmpdir):
+    tmpdir.join('default').mkdir()
+
+    db = Database([tmpdir.join('default')], tmpdir.join('cache.sqlite3'))
+    list_ = next(db.lists())
+
+    assert list_.color_raw is None
+    assert list_.color_rgb is None
+    assert list_.color_ansi is None

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,20 +1,25 @@
+from datetime import datetime
+
 import pytest
+import pytz
+from freezegun import freeze_time
 from urwid import ExitMainLoop
 
 from todoman.ui import TodoEditor, TodoFormatter
 
-DATE_FORMAT = "%d-%m-%y"
+DATE_FORMAT = "%Y-%m-%d"
 TIME_FORMAT = "%H:%M"
 
 
 def test_todo_editor_priority(default_database, todo_factory):
     todo = todo_factory(priority=1)
     lists = list(default_database.lists())
-    formatter = TodoFormatter(DATE_FORMAT, TIME_FORMAT, '')
+    formatter = TodoFormatter(DATE_FORMAT, TIME_FORMAT, ' ')
 
     editor = TodoEditor(todo, lists, formatter)
-    editor._priority.edit_text = ''
+    assert editor._priority.edit_text == 'high'
 
+    editor._priority.edit_text = ''
     with pytest.raises(ExitMainLoop):  # Look at editor._msg_text if this fails
         editor._keypress('ctrl s')
 
@@ -22,3 +27,37 @@ def test_todo_editor_priority(default_database, todo_factory):
     assert todo.priority is 0
     # The actual todo contains None
     assert todo.todo.get('priority', None) is None
+
+
+def test_todo_editor_summary(default_database, todo_factory):
+    todo = todo_factory()
+    lists = list(default_database.lists())
+    formatter = TodoFormatter(DATE_FORMAT, TIME_FORMAT, ' ')
+
+    editor = TodoEditor(todo, lists, formatter)
+    assert editor._summary.edit_text == 'YARR!'
+
+    editor._summary.edit_text = 'Goodbye'
+    with pytest.raises(ExitMainLoop):  # Look at editor._msg_text if this fails
+        editor._keypress('ctrl s')
+
+    assert todo.summary == 'Goodbye'
+
+
+@freeze_time('2017-03-04 14:00:00', tz_offset=4)
+def test_todo_editor_due(default_database, todo_factory):
+    tz = pytz.timezone('CET')
+
+    todo = todo_factory(due=datetime(2017, 3, 4, 14))
+    lists = list(default_database.lists())
+    formatter = TodoFormatter(DATE_FORMAT, TIME_FORMAT, ' ')
+    formatter._localtimezone = tz
+
+    editor = TodoEditor(todo, lists, formatter)
+    assert editor._due.edit_text == '2017-03-04 14:00'
+
+    editor._due.edit_text = '2017-03-10 12:00'
+    with pytest.raises(ExitMainLoop):  # Look at editor._msg_text if this fails
+        editor._keypress('ctrl s')
+
+    assert todo.due == datetime(2017, 3, 10, 12, tzinfo=tz)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -3,7 +3,7 @@ from todoman.widgets import ExtendedEdit
 # We ignore `size` when testing keypresses, because it's not used anywhere.
 # Just pass any number when writing tests, unless we start using the value.
 
-BASE_STRING = 'The lazy fox bla bla'
+BASE_STRING = 'The lazy fox bla bla\n@ät'
 
 
 def test_extended_edit_delete_word():
@@ -13,19 +13,19 @@ def test_extended_edit_delete_word():
     extended_edit.edit_pos = 9
     extended_edit.keypress(10, 'ctrl w')
     assert extended_edit.edit_pos == 4
-    assert extended_edit.get_edit_text() == 'The fox bla bla'
+    assert extended_edit.get_edit_text() == 'The fox bla bla\n@ät'
 
-    extended_edit.set_edit_text('The-lazy-fox-bla-bla')
+    extended_edit.set_edit_text('The-lazy-fox-bla-bla\n@ät')
     extended_edit.edit_pos = 8
     extended_edit.keypress(10, 'ctrl w')
     assert extended_edit.edit_pos == 4
-    assert extended_edit.get_edit_text() == 'The--fox-bla-bla'
+    assert extended_edit.get_edit_text() == 'The--fox-bla-bla\n@ät'
 
     extended_edit.set_edit_text(BASE_STRING)
     extended_edit.edit_pos = 6
     extended_edit.keypress(10, 'ctrl w')
     assert extended_edit.edit_pos == 4
-    assert extended_edit.get_edit_text() == 'The zy fox bla bla'
+    assert extended_edit.get_edit_text() == 'The zy fox bla bla\n@ät'
 
     extended_edit.set_edit_text(BASE_STRING)
     extended_edit.edit_pos = 0
@@ -41,7 +41,7 @@ def test_extended_edit_delete_sol():
     extended_edit.edit_pos = 9
     extended_edit.keypress(10, 'ctrl u')
     assert extended_edit.edit_pos == 0
-    assert extended_edit.get_edit_text() == 'fox bla bla'
+    assert extended_edit.get_edit_text() == 'fox bla bla\n@ät'
 
     extended_edit.set_edit_text(BASE_STRING)
     extended_edit.edit_pos = 0
@@ -57,12 +57,18 @@ def test_extended_edit_delete_eol():
     extended_edit.edit_pos = 9
     extended_edit.keypress(10, 'ctrl k')
     assert extended_edit.edit_pos == 9
-    assert extended_edit.get_edit_text() == 'The lazy '
+    assert extended_edit.get_edit_text() == 'The lazy \n@ät'
 
     extended_edit.set_edit_text(BASE_STRING)
     extended_edit.edit_pos = 20
     extended_edit.keypress(10, 'ctrl k')
     assert extended_edit.edit_pos == 20
+    assert extended_edit.get_edit_text() == BASE_STRING
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 24
+    extended_edit.keypress(10, 'ctrl k')
+    assert extended_edit.edit_pos == 24
     assert extended_edit.get_edit_text() == BASE_STRING
 
 
@@ -75,6 +81,12 @@ def test_extended_edit_goto_sol():
     assert extended_edit.edit_pos == 0
     assert extended_edit.get_edit_text() == BASE_STRING
 
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 23
+    extended_edit.keypress(10, 'ctrl a')
+    assert extended_edit.edit_pos == 21
+    assert extended_edit.get_edit_text() == BASE_STRING
+
 
 def test_extended_edit_goto_eol():
     extended_edit = ExtendedEdit(None)
@@ -85,6 +97,12 @@ def test_extended_edit_goto_eol():
     assert extended_edit.edit_pos == 20
     assert extended_edit.get_edit_text() == BASE_STRING
 
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 22
+    extended_edit.keypress(10, 'ctrl e')
+    assert extended_edit.edit_pos == 24
+    assert extended_edit.get_edit_text() == BASE_STRING
+
 
 def test_extended_edit_delete_next_char():
     extended_edit = ExtendedEdit(None)
@@ -93,20 +111,25 @@ def test_extended_edit_delete_next_char():
     extended_edit.edit_pos = 9
     extended_edit.keypress(10, 'ctrl d')
     assert extended_edit.edit_pos == 9
-    assert extended_edit.get_edit_text() == 'The lazy ox bla bla'
+    assert extended_edit.get_edit_text() == 'The lazy ox bla bla\n@ät'
 
     extended_edit.set_edit_text(BASE_STRING)
     extended_edit.edit_pos = 0
     extended_edit.keypress(10, 'ctrl d')
     assert extended_edit.edit_pos == 0
-    assert extended_edit.get_edit_text() == 'he lazy fox bla bla'
+    assert extended_edit.get_edit_text() == 'he lazy fox bla bla\n@ät'
 
     extended_edit.set_edit_text(BASE_STRING)
-    extended_edit.edit_pos = 20
+    extended_edit.edit_pos = 24
     extended_edit.keypress(10, 'ctrl d')
-    assert extended_edit.edit_pos == 20
-    assert extended_edit.get_edit_text() == BASE_STRING
+    assert extended_edit.edit_pos == 24
+    assert extended_edit.get_edit_text() == 'The lazy fox bla bla\n@ät'
 
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 24
+    extended_edit.keypress(10, 'ctrl d')
+    assert extended_edit.edit_pos == 24
+    assert extended_edit.get_edit_text() == 'The lazy fox bla bla\n@ät'
 
 # TODO: plain ol' keypresses
 # TODO: can we test ctrl o (maybe with some unittest.mock?)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,112 @@
+from todoman.widgets import ExtendedEdit
+
+# We ignore `size` when testing keypresses, because it's not used anywhere.
+# Just pass any number when writing tests, unless we start using the value.
+
+BASE_STRING = 'The lazy fox bla bla'
+
+
+def test_extended_edit_delete_word():
+    extended_edit = ExtendedEdit(None)
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 9
+    extended_edit.keypress(10, 'ctrl w')
+    assert extended_edit.edit_pos == 4
+    assert extended_edit.get_edit_text() == 'The fox bla bla'
+
+    extended_edit.set_edit_text('The-lazy-fox-bla-bla')
+    extended_edit.edit_pos = 8
+    extended_edit.keypress(10, 'ctrl w')
+    assert extended_edit.edit_pos == 4
+    assert extended_edit.get_edit_text() == 'The--fox-bla-bla'
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 6
+    extended_edit.keypress(10, 'ctrl w')
+    assert extended_edit.edit_pos == 4
+    assert extended_edit.get_edit_text() == 'The zy fox bla bla'
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 0
+    extended_edit.keypress(10, 'ctrl w')
+    assert extended_edit.edit_pos == 0
+    assert extended_edit.get_edit_text() == BASE_STRING
+
+
+def test_extended_edit_delete_sol():
+    extended_edit = ExtendedEdit(None)
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 9
+    extended_edit.keypress(10, 'ctrl u')
+    assert extended_edit.edit_pos == 0
+    assert extended_edit.get_edit_text() == 'fox bla bla'
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 0
+    extended_edit.keypress(10, 'ctrl u')
+    assert extended_edit.edit_pos == 0
+    assert extended_edit.get_edit_text() == BASE_STRING
+
+
+def test_extended_edit_delete_eol():
+    extended_edit = ExtendedEdit(None)
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 9
+    extended_edit.keypress(10, 'ctrl k')
+    assert extended_edit.edit_pos == 9
+    assert extended_edit.get_edit_text() == 'The lazy '
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 20
+    extended_edit.keypress(10, 'ctrl k')
+    assert extended_edit.edit_pos == 20
+    assert extended_edit.get_edit_text() == BASE_STRING
+
+
+def test_extended_edit_goto_sol():
+    extended_edit = ExtendedEdit(None)
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 9
+    extended_edit.keypress(10, 'ctrl a')
+    assert extended_edit.edit_pos == 0
+    assert extended_edit.get_edit_text() == BASE_STRING
+
+
+def test_extended_edit_goto_eol():
+    extended_edit = ExtendedEdit(None)
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 9
+    extended_edit.keypress(10, 'ctrl e')
+    assert extended_edit.edit_pos == 20
+    assert extended_edit.get_edit_text() == BASE_STRING
+
+
+def test_extended_edit_delete_next_char():
+    extended_edit = ExtendedEdit(None)
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 9
+    extended_edit.keypress(10, 'ctrl d')
+    assert extended_edit.edit_pos == 9
+    assert extended_edit.get_edit_text() == 'The lazy ox bla bla'
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 0
+    extended_edit.keypress(10, 'ctrl d')
+    assert extended_edit.edit_pos == 0
+    assert extended_edit.get_edit_text() == 'he lazy fox bla bla'
+
+    extended_edit.set_edit_text(BASE_STRING)
+    extended_edit.edit_pos = 20
+    extended_edit.keypress(10, 'ctrl d')
+    assert extended_edit.edit_pos == 20
+    assert extended_edit.get_edit_text() == BASE_STRING
+
+
+# TODO: plain ol' keypresses
+# TODO: can we test ctrl o (maybe with some unittest.mock?)

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -25,11 +25,11 @@ def _validate_lists_param(ctx, param=None, lists=None):
 def _validate_list_param(ctx, param=None, name=None):
     ctx = ctx.find_object(AppContext)
     if name is None:
-        if 'default_list' in ctx.config['main']:
+        if ctx.config['main']['default_list']:
             name = ctx.config['main']['default_list']
         else:
             raise click.BadParameter(
-                "{}. You must set 'default_list' or use -l."
+                'You must set "default_list" or use -l.'
                 .format(name)
             )
     for l in ctx.db.lists():

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -754,9 +754,16 @@ class List:
 
     @cached_property
     def color_rgb(self):
-        rv = self.color_raw
-        if rv:
-            return _parse_color(rv)
+        color = self.color_raw
+        if not color or not color.startswith('#'):
+            return
+
+        r = color[1:3]
+        g = color[3:5]
+        b = color[5:8]
+
+        if len(r) == len(g) == len(b) == 2:
+            return int(r, 16), int(g, 16), int(b, 16)
 
     @cached_property
     def color_ansi(self):
@@ -876,18 +883,6 @@ class Database:
         id = self.cache.add_todo(todo, path)
         self.cache.save_to_disk()
         todo.id = id
-
-
-def _parse_color(color):
-    if not color.startswith('#'):
-        return
-
-    r = color[1:3]
-    g = color[3:5]
-    b = color[5:8]
-
-    if len(r) == len(g) == len(b) == 2:
-        return int(r, 16), int(g, 16), int(b, 16)
 
 
 def _getmtime(path):

--- a/todoman/ui.py
+++ b/todoman/ui.py
@@ -231,14 +231,7 @@ class TodoFormatter:
             percent = todo.percent_complete or ''
             if percent:
                 percent = " ({}%)".format(percent)
-            if todo.priority == 5:
-                priority = "!!"
-            elif todo.priority <= 4 and todo.priority >= 1:
-                priority = "!!!"
-            elif todo.priority <= 9 and todo.priority >= 6:
-                priority = "!"
-            elif todo.priority == 0:
-                priority = ""
+            priority = self.format_priority_compact(todo.priority)
 
             due = self.format_datetime(todo.due)
             if todo.due and todo.due <= self.now and not todo.is_completed:
@@ -335,6 +328,16 @@ class TodoFormatter:
             return 'medium'
         elif 6 <= priority <= 9:
             return 'low'
+
+    def format_priority_compact(self, priority):
+        if not priority:
+            return ''
+        elif 1 <= priority <= 4:
+            return "!!!"
+        elif priority == 5:
+            return "!!"
+        elif 6 <= priority <= 9:
+            return "!"
 
     def parse_datetime(self, dt):
         if not dt:

--- a/todoman/widgets.py
+++ b/todoman/widgets.py
@@ -86,10 +86,8 @@ class ExtendedEdit(urwid.Edit):
     def _delete_till_beginning_of_line(self):
         """delete till start of line before cursor"""
         text = self.get_edit_text()
-        sol = text.rfind('\n', self.edit_pos)
+        sol = text.rfind('\n', 0, self.edit_pos) + 1
 
-        if sol == -1:
-            sol = 0
         before_line = text[:sol]
 
         self.set_edit_text(before_line + text[self.edit_pos:])
@@ -109,9 +107,7 @@ class ExtendedEdit(urwid.Edit):
 
     def _goto_beginning_of_line(self):
         text = self.get_edit_text()
-        sol = text.rfind('\n', 0, self.edit_pos)
-        if sol == -1:
-            sol = 0
+        sol = text.rfind('\n', 0, self.edit_pos) + 1
         self.set_edit_pos(sol)
 
     def _goto_end_of_line(self):


### PR DESCRIPTION
I merge two branches into this one, because they had too much overlap.

I'd like to increase coverage (not just the number, but also edge cases too).

We also have all sorts of tiny bugs hidden around, like, for example, we show the wrong message in certain scenarios, eg: if `default_list = nonexistant`:

```
$ todo new dafsd
Usage: todo new [OPTIONS] [SUMMARY]...

Error: Invalid value for "--list" / "-l": personal2. Available lists are: holidays, Shiftgig, study, personal, work
```

In this case:
* Config was wrong
* There was no `-l`