### PR TITLE
Don't require quoting args of --start

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -268,11 +268,11 @@ def test_filtering_start(tmpdir, runner, create):
     now = today.strftime("%Y-%m-%d")
     now_plus_day = (today + timedelta(days=1)).strftime("%Y-%m-%d")
     now_minus_day = (today + timedelta(days=-1)).strftime("%Y-%m-%d")
-    result = runner.invoke(cli, ['list', '--start', 'before ' + now])
+    result = runner.invoke(cli, ['list', '--start', 'before', now])
     assert not result.exception
     assert not result.output.strip()
 
-    result = runner.invoke(cli, ['list', '--start', 'after ' + now])
+    result = runner.invoke(cli, ['list', '--start', 'after', now])
     assert not result.exception
     assert not result.output.strip()
 
@@ -280,13 +280,13 @@ def test_filtering_start(tmpdir, runner, create):
     runner.invoke(cli, ['new', '-l', 'list_one', 'haha'])
     runner.invoke(cli, ['new', '-l', 'list_one', 'hoho'])
 
-    result = runner.invoke(cli, ['list', '--start', 'after ' + now_minus_day])
+    result = runner.invoke(cli, ['list', '--start', 'after', now_minus_day])
     assert not result.exception
     assert 'haha' in result.output
     assert 'hoho' in result.output
-    result = runner.invoke(cli, ['list', '--start', 'before ' + now_minus_day])
+    result = runner.invoke(cli, ['list', '--start', 'before', now_minus_day])
     assert not result.exception
     assert not result.output.strip()
-    result = runner.invoke(cli, ['list', '--start', 'after ' + now_plus_day])
+    result = runner.invoke(cli, ['list', '--start', 'after', now_plus_day])
     assert not result.exception
     assert not result.output.strip()

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -61,20 +61,17 @@ def _validate_priority_param(ctx, param, val):
 
 def _validate_start_date_param(ctx, param, val):
     ctx = ctx.find_object(AppContext)
-    if val is None:
+    if not val:
         return val
-    if val.startswith('before '):
-        is_before = True
-        val = val[len('before '):]
-    elif val.startswith('after '):
-        is_before = False
-        val = val[len('after '):]
-    else:
+
+    if val[0] not in ['before', 'after']:
         raise click.BadParameter(
-            "The start date of the task should be"
-            "in format '[before|after] <date-format>'")
+            "Format should be '[before|after] [DATE]'")
+
+    is_before = val[0] == 'before'
+
     try:
-        dt = ctx.formatter.parse_datetime(val)
+        dt = ctx.formatter.parse_datetime(val[1])
         return is_before, dt
     except ValueError as e:
         raise click.BadParameter(e)
@@ -423,7 +420,7 @@ def move(ctx, list, ids):
 @click.option('--done-only', default=False, is_flag=True,
               help='Only show finished tasks')
 @click.option('--start', default=None, callback=_validate_start_date_param,
-              help='Only shows tasks before/after given DATE')
+              nargs=2, help='Only shows tasks before/after given DATE')
 @catch_errors
 def list(ctx, **kwargs):
     """


### PR DESCRIPTION
By design, we used to have require that the arguments of --start be quoted, eg:

    todo list --start "after 2017-03-18"

Drop this requirement, and treat both things as two different arguments.