### PR TITLE
Various bugfixes and cleanups for the UI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def todo_factory(default_database):
         for name, value in attributes.items():
             setattr(todo, name, value)
 
-        todo.save()
+        default_database.save(todo)
 
         return todo
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -544,7 +544,7 @@ def test_todo_new(runner, default_database):
     with patch('urwid.MainLoop'):
         result = runner.invoke(cli, ['new', '-l', 'default'])
 
-    # Unsaved exit
+    # No SUMMARY error after UI runs
     assert isinstance(result.exception, SystemExit)
-    assert result.exception.args == (1,)
-    assert result.output == ''
+    assert result.exception.args == (2,)
+    assert 'Error: No SUMMARY specified' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -548,3 +548,15 @@ def test_todo_new(runner, default_database):
     assert isinstance(result.exception, SystemExit)
     assert result.exception.args == (2,)
     assert 'Error: No SUMMARY specified' in result.output
+
+
+def test_todo_edit(runner, default_database, todo_factory):
+    # This isn't a very thurough test, but at least catches obvious regressions
+    # like startup crashes or typos.
+    todo_factory()
+
+    with patch('urwid.MainLoop'):
+        result = runner.invoke(cli, ['edit', '1'])
+
+    assert not result.exception
+    assert 'YARR!' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,7 +279,7 @@ def test_sorting_fields(tmpdir, runner, default_database):
         todo.summary = 'harhar{}'.format(i)
         tasks.append(todo)
 
-        todo.save()
+        default_database.save(todo)
 
     fields = (
         'id',
@@ -424,7 +424,7 @@ def test_edit(runner, default_database):
     todo.list = next(default_database.lists())
     todo.summary = 'Eat paint'
     todo.due = datetime.datetime(2016, 10, 3)
-    todo.save()
+    default_database.save(todo)
 
     result = runner.invoke(cli, ['edit', '1', '--due', '2017-02-01'])
     assert not result.exception

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -227,7 +227,8 @@ def test_due_aware(tmpdir, runner, create, now_for_tz):
             todo.due = now_for_tz(tz) + timedelta(hours=i)
             todo.summary = '{}'.format(i)
 
-            db.save(todo, l)
+            todo.list = l
+            db.save(todo)
 
     todos = list(db.todos(due=24))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -248,3 +248,26 @@ def test_list_equality(tmpdir):
     assert list1 == list2
     assert list1 != list3
     assert list1 != 'test list'
+
+
+def test_clone():
+    now = datetime.now(tz=tzlocal())
+
+    todo = Todo(new=True)
+    todo.summary = 'Organize a party'
+    todo.location = 'Home'
+    todo.due = now
+    todo.uid = '123'
+    todo.id = '123'
+    todo.filename = '123.ics'
+
+    clone = todo.clone()
+
+    assert todo.summary == clone.summary
+    assert todo.location == clone.location
+    assert todo.due == clone.due
+    assert todo.uid != clone.uid
+    assert len(clone.uid) > 32
+    assert clone.id is None
+    assert todo.filename != clone.filename
+    assert clone.uid in clone.filename

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -288,9 +288,11 @@ def edit(ctx, id, todo_properties, interactive):
         ui.edit()
 
     # This little dance avoids duplicates when changing the list:
-    todo.save(old_list)
-    if old_list.name != todo.list.name:
-        ctx.db.move(todo, todo.list, from_list=old_list)
+    new_list = todo.list
+    todo.list = old_list
+    ctx.db.save(todo)
+    if old_list != new_list:
+        ctx.db.move(todo, new_list=new_list, from_list=old_list)
     click.echo(ctx.formatter.detailed(todo))
 
 
@@ -317,7 +319,7 @@ def done(ctx, ids):
     for id in ids:
         todo = ctx.db.todo(id)
         todo.is_completed = True
-        todo.save()
+        ctx.db.save(todo)
         click.echo(ctx.formatter.detailed(todo))
 
 
@@ -373,9 +375,11 @@ def copy(ctx, list, ids):
     '''Copy tasks to another list.'''
 
     for id in ids:
-        todo = ctx.db.todo(id)
+        original = ctx.db.todo(id)
+        todo = original.clone()
+        todo.list = list
         click.echo(ctx.formatter.compact(todo))
-        ctx.db.save(todo, list)
+        ctx.db.save(todo)
 
 
 @cli.command()

--- a/todoman/interactive.py
+++ b/todoman/interactive.py
@@ -7,11 +7,6 @@ _palette = [
 ]
 
 
-class EditState:
-    none = object()
-    saved = object()
-
-
 class TodoEditor:
     """
     The UI for a single todo entry.
@@ -25,7 +20,6 @@ class TodoEditor:
         self.todo = todo
         self.lists = list(lists)
         self.formatter = formatter
-        self.saved = EditState.none
         self._loop = None
 
         self._msg_text = urwid.Text('')
@@ -111,10 +105,7 @@ class TodoEditor:
         self._msg_text.set_text(text)
 
     def edit(self):
-        """
-        Shows the UI for editing a given todo. Returns True if modifications
-        were saved.
-        """
+        """Shows the UI for editing a given todo."""
         self._loop = urwid.MainLoop(
             self._ui,
             palette=_palette,
@@ -130,7 +121,6 @@ class TodoEditor:
                 pass
             raise
         self._loop = None
-        return self.saved
 
     def _save(self, btn=None):
         try:
@@ -138,7 +128,6 @@ class TodoEditor:
         except Exception as e:
             self.message(('error', str(e)))
         else:
-            self.saved = EditState.saved
             raise urwid.ExitMainLoop()
 
     def _save_inner(self):

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -95,6 +95,8 @@ class Todo:
 
         if new:
             self.created_at = now
+        else:
+            self.created_at = None
 
         # Default values for supported fields
         self.categories = []
@@ -119,6 +121,28 @@ class Todo:
             )
         self.mtime = mtime or datetime.now()
 
+    def clone(self):
+        """
+        Returns a clone of this todo
+
+        Returns a copy of this todo, which is almost identical, except that is
+        has a different UUID and filename.
+        """
+        todo = Todo(new=True, list=self.list)
+
+        fields = (
+            Todo.STRING_FIELDS +
+            Todo.INT_FIELDS +
+            Todo.LIST_FIELDS +
+            Todo.DATETIME_FIELDS
+        )
+        fields.remove('uid')
+
+        for field in fields:
+            setattr(todo, field, getattr(self, field))
+
+        return todo
+
     STRING_FIELDS = [
         'description',
         'location',
@@ -135,11 +159,10 @@ class Todo:
         'categories',
     ]
     DATETIME_FIELDS = [
-        'completed',
-        'created',
+        'completed_at',
         'created_at',
         'dtstamp',
-        'dtstart',
+        'start',
         'due',
     ]
 

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -86,10 +86,12 @@ class Todo:
         Todo.
         :param bool new: Indicate that a new Todo is being created and should
         be populated with default values.
+        :param List list: The list to which this Todo belongs.
         """
         self.list = list
         now = datetime.now(LOCAL_TIMEZONE)
         self.uid = '{}@{}'.format(uuid4().hex, socket.gethostname())
+        self.list = list
 
         if new:
             self.created_at = now


### PR DESCRIPTION
This PR ended up being a bit more kitchen-sink than I expected (see commit message for individual details):

* Remove now-senseless `EditState`.
* We set the list passed via cli to a Todo before opening the editor, so editor changes are lost.
* If a Todo is edited and the list is changed, we actually save into the new list, rather than copying.
* Simplify all the saving code, which ended up being more complex due to gradual patching.
* Retain `id`s after saving (fixes #85).