### PR TITLE
Fix a bug serializing created_at/start

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+import pytest
+import pytz
+
+from todoman.model import Todo, VtodoWritter
+
+
+def test_serialize_created_at(todo_factory):
+    now = datetime.now(tz=pytz.UTC)
+    todo = todo_factory(created_at=now)
+    vtodo = VtodoWritter(todo).serialize()
+
+    assert vtodo.get('created') is not None
+
+
+def test_serialize_dtstart(todo_factory):
+    now = datetime.now(tz=pytz.UTC)
+    todo = todo_factory(start=now)
+    vtodo = VtodoWritter(todo).serialize()
+
+    assert vtodo.get('dtstart') is not None
+
+
+def test_serializer_raises(todo_factory):
+    todo = todo_factory()
+    writter = VtodoWritter(todo)
+
+    with pytest.raises(Exception):
+        writter.serialize_field('nonexistant', 7)
+
+
+def test_supported_fields_are_serializeable():
+    supported_fields = set(
+        Todo.DATETIME_FIELDS +
+        Todo.INT_FIELDS +
+        Todo.LIST_FIELDS +
+        Todo.STRING_FIELDS
+    )
+    serialized_fields = set(VtodoWritter.FIELD_MAP.keys())
+
+    assert supported_fields == serialized_fields

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -258,12 +258,9 @@ class VtodoWritter:
         if name in Todo.STRING_FIELDS:
             return value
 
-        logger.warn('Unknown field %s serialized.', name)
-        return value
+        raise Exception('Unknown field {} serialized.'.format(name))
 
     def set_field(self, name, value):
-        value = self.serialize_field(name, value)
-
         if name in self.vtodo:
             del(self.vtodo[name])
         if value:
@@ -278,7 +275,10 @@ class VtodoWritter:
 
         for source, target in self.FIELD_MAP.items():
             if getattr(self.todo, source):
-                self.set_field(target, getattr(self.todo, source))
+                self.set_field(
+                    target,
+                    self.serialize_field(source, getattr(self.todo, source)),
+                )
 
         return self.vtodo
 


### PR DESCRIPTION
These fields weren't being serialized. Check that we serialize them, and also make sure that all supported fields are serializeable and viceversa.