### PR TITLE
Add test to for uid/filename colition on save

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -281,3 +281,21 @@ def test_todos_today(tmpdir, runner, todo_factory, default_database):
     assert len(todos) == 2
     for todo in todos:
         assert 'unstarted' not in todo.summary
+
+
+def test_filename_uid_colision(create, default_database, runner):
+    create(
+        'ABC.ics',
+        'SUMMARY:My UID is not ABC\n'
+        'UID:NOTABC\n'
+    )
+    default_database.update_cache()
+    len(list(default_database.todos())) == 1
+
+    todo = Todo(new=False)
+    todo.uid = 'ABC'
+    todo.list = next(default_database.lists())
+    default_database.save(todo)
+
+    default_database.update_cache()
+    len(list(default_database.todos())) == 2


### PR DESCRIPTION
Due to how our save logic is implemented, I suspected that this
particular scenario would have a silent failure when attempting to save.

Fortunately, we pre-define a Todo's filename on-initialization, so it's
not a bug (merely by coincidence).

Let's keep the test around just in case we introduce a regression like
this in future.