### PR TITLE
Allow fine-grained filtering by status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ releases, in reverse chronological order.
 v3.1.0
 ------
 
+* Replace ``--all`` and ``--done-only`` with  ``--status``, which allows
+  fine-grained status filtering. Use ``--status ANY`` or ``--status COMPLETED``
+  to obtain the same results as the previous flags.
 * Rename ``--today`` flag to ``--startable``.
 * Illegal start dates (eg: start dates that are not before the due date) are
   ignored and are removed when saving an edited todo.

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -23,7 +23,7 @@ def test_humanized_date(runner, create, interval, now_for_tz, tz):
         .format(tz, due.strftime('%Y%m%dT%H%M%S'))
     )
 
-    result = runner.invoke(cli, ['--humanize', 'list', '--all'])
+    result = runner.invoke(cli, ['--humanize', 'list', '--status', 'ANY'])
     assert not result.exception
     assert expected in result.output
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -301,7 +301,7 @@ def test_hide_cancelled(todos, todo_factory):
     todo_factory(status='CANCELLED')
 
     assert len(list(todos())) == 0
-    assert len(list(todos(all=True))) == 1
+    assert len(list(todos(status='ANY'))) == 1
 
 
 def test_illegal_start_suppression(create, default_database, todos):
@@ -314,3 +314,12 @@ def test_illegal_start_suppression(create, default_database, todos):
     todo = next(todos())
     assert todo.start is None
     assert todo.due == datetime(2017, 3, 31, 12, tzinfo=tzoffset(None, 7200))
+
+
+def test_default_status(create, todos):
+    create(
+        'test.ics',
+        'SUMMARY:Finish all these status tests\n'
+    )
+    todo = next(todos())
+    assert todo.status == 'NEEDS-ACTION'

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -15,7 +15,7 @@ def test_list_all(tmpdir, runner, create):
         'DUE;VALUE=DATE-TIME;TZID=CET:20160102T000000\n'
         'PERCENT-COMPLETE:26\n'
     )
-    result = runner.invoke(cli, ['--porcelain', 'list', '--all'])
+    result = runner.invoke(cli, ['--porcelain', 'list', '--status', 'ANY'])
 
     expected = [{
         'completed': True,

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -454,16 +454,16 @@ def move(ctx, list, ids):
 @click.option('--reverse/--no-reverse', default=True,
               help='Sort tasks in reverse order (see --sort). '
               'Defaults to true.')
-@click.option('--due', default=None, help='Only show tasks due in DUE hours',
-              type=int)
+@click.option('--due', default=None, help='Only show tasks due in INTEGER '
+              'hours', type=int)
 @click.option('--priority', default=None, help='Only show tasks with'
-              ' priority at least as high as the specified one', type=str,
-              callback=_validate_priority_param)
+              ' priority at least as high as TEXT (low, medium or high).',
+              type=str, callback=_validate_priority_param)
 @click.option('--start', default=None, callback=_validate_start_date_param,
               nargs=2, help='Only shows tasks before/after given DATE')
 @click.option('--startable', default=None, is_flag=True,
               callback=_validate_startable_param, help='Show only todos which '
-              'should can be started today (eg: start time is not in the '
+              'should can be started today (i.e.: start time is not in the '
               'future).')
 @click.option('--status', '-s', default=['NEEDS-ACTION', 'IN-PROCESS'],
               callback=validate_status, help='Show only todos with the '
@@ -473,10 +473,11 @@ def move(ctx, list, ids):
 @catch_errors
 def list(ctx, **kwargs):
     """
-    List unfinished tasks.
+    List tasks. Filters any completed or cancelled tasks by default.
 
-    If no arguments are provided, all lists will be displayed. Otherwise, only
-    todos for the specified list will be displayed.
+    If no arguments are provided, all lists will be displayed, and only
+    incomplete tasks are show. Otherwise, only todos for the specified list
+    will be displayed.
 
     eg:
       \b
@@ -484,6 +485,9 @@ def list(ctx, **kwargs):
       - `todo list work' shows all unfinished tasks from the list `work`.
 
     This is the default action when running `todo'.
+
+    The following commands can further filter shown todos, or include those
+    omited by default:
     """
     todos = ctx.db.todos(**kwargs)
     click.echo(ctx.formatter.compact_multiple(todos))


### PR DESCRIPTION
This replaces filtering via `--all` and `--done-only` with fine-grained
status filtering. Previous results can be obtained with `status=ANY` and
`status=COMPLETED`.