### PR TITLE
Allow completing recurring todos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+v3.2.0
+------
+
+* Completing recurring todos now works as expected and does not make if
+  dissapear forever.
+
 v3.1.0
 ------
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import icalendar
 import pytest
 import pytz
 from dateutil.tz import tzlocal
@@ -49,6 +50,7 @@ def test_vtodo_serialization(todo_factory):
         priority=7,
         status='IN-PROCESS',
         summary='Some tea',
+        rrule='FREQ=MONTHLY',
     )
     writer = VtodoWritter(todo)
     vtodo = writer.serialize()
@@ -58,6 +60,7 @@ def test_vtodo_serialization(todo_factory):
     assert vtodo.get('priority') == 7
     assert vtodo.decoded('due') == datetime(3000, 3, 21, tzinfo=tzlocal())
     assert str(vtodo.get('status')) == 'IN-PROCESS'
+    assert vtodo.get('rrule') == icalendar.vRecur.from_ical('FREQ=MONTHLY')
 
 
 @freeze_time('2017-04-04 20:11:57')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -735,6 +735,25 @@ def test_done(runner, todo_factory, todos):
     assert result.output.strip() == 'No todo with id 17.'
 
 
+def test_done_recurring(runner, todo_factory, todos):
+    rrule = 'FREQ=DAILY;UNTIL=20990315T020000Z'
+    todo = todo_factory(rrule=rrule)
+
+    result = runner.invoke(cli, ['done', '1'])
+    assert not result.exception
+
+    todos = todos(status='ANY')
+    todo = next(todos)
+    assert todo.percent_complete == 100
+    assert todo.is_completed is True
+    assert not todo.rrule
+
+    todo = next(todos)
+    assert todo.percent_complete == 0
+    assert todo.is_completed is False
+    assert todo.rrule == rrule
+
+
 def test_cancel(runner, todo_factory, todos):
     todo = todo_factory()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -182,25 +182,18 @@ def test_todo_setters(todo_factory):
 
 @freeze_time('2017-03-19-15')
 def test_is_completed():
-    completed_at = datetime(2017, 3, 19, 14, tzinfo=pytz.UTC),
+    completed_at = datetime(2017, 3, 19, 14, tzinfo=pytz.UTC)
 
     todo = Todo()
+    assert todo.is_completed is False
+
     todo.completed_at = completed_at
+    assert todo.is_completed is True
+
     todo.percent_complete = 20
-
-    todo.is_completed = True
-    assert todo.completed_at == completed_at
-    assert todo.percent_complete == 100
-    assert todo.status == 'COMPLETED'
-
-    todo.is_completed = False
-    assert todo.completed_at is None
-    assert todo.percent_complete == 0
-    assert todo.status == 'NEEDS-ACTION'
-
-    todo.is_completed = True
-    now = datetime(2017, 3, 19, 15, tzinfo=pytz.UTC).astimezone(tzlocal())
-    assert todo.completed_at == now
+    todo.complete()
+    assert todo.is_completed is True
+    assert todo.completed_at == datetime.now(pytz.UTC)
     assert todo.percent_complete == 100
     assert todo.status == 'COMPLETED'
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -292,3 +292,16 @@ def test_default_status(create, todos):
     )
     todo = next(todos())
     assert todo.status == 'NEEDS-ACTION'
+
+
+def test_nullify_field(default_database, todo_factory, todos):
+    todo_factory(due=datetime.now())
+
+    todo = next(todos(status='ANY'))
+    assert todo.due is not None
+
+    todo.due = None
+    default_database.save(todo)
+
+    todo = next(todos(status='ANY'))
+    assert todo.due is None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 import pytz
@@ -196,6 +196,73 @@ def test_is_completed():
     assert todo.completed_at == datetime.now(pytz.UTC)
     assert todo.percent_complete == 100
     assert todo.status == 'COMPLETED'
+
+
+@pytest.mark.parametrize('until', [
+    '20990315T020000Z',  # TZ-aware UNTIL
+    '20990315T020000',  # TZ-naive UNTIL
+])
+@pytest.mark.parametrize('tz', [
+    pytz.UTC,  # TZ-aware todos
+    None,  # TZ-naive todos
+])
+@pytest.mark.parametrize('due', [
+    True,
+    False,
+])
+def test_complete_recurring(default_database, due, todo_factory, tz, until):
+    # We'll lose the milis when casting, so:
+    now = datetime.now(tz).replace(microsecond=0)
+
+    original_start = now
+    if due:
+        original_due = now + timedelta(hours=12)
+    else:
+        due = original_due = None
+
+    rrule = 'FREQ=DAILY;UNTIL=20990315T020000Z'
+    todo = todo_factory(rrule=rrule, due=original_due, start=original_start)
+
+    todo.complete()
+    related = todo.related[0]
+
+    if due:
+        assert todo.due == original_due
+    else:
+        assert todo.due is None
+    assert todo.start == original_start
+    assert todo.is_completed
+    assert not todo.rrule
+
+    if due:
+        assert related.due == original_due + timedelta(days=1)
+    else:
+        assert related.due is None
+    assert related.start == original_start + timedelta(days=1)
+    # check due/start tz
+    assert not related.is_completed
+    assert related.rrule == rrule
+
+
+def test_save_recurring_related(default_database, todo_factory, todos):
+    now = datetime.now(pytz.UTC)
+    original_due = now + timedelta(hours=12)
+    rrule = 'FREQ=DAILY;UNTIL=20990315T020000Z'
+    todo = todo_factory(rrule=rrule, due=original_due)
+    todo.complete()
+
+    default_database.save(todo)
+
+    todos = todos(status='ANY')
+    todo = next(todos)
+    assert todo.percent_complete == 100
+    assert todo.is_completed is True
+    assert not todo.rrule
+
+    todo = next(todos)
+    assert todo.percent_complete == 0
+    assert todo.is_completed is False
+    assert todo.rrule == rrule
 
 
 def test_todo_filename_absolute_path():

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -129,3 +129,17 @@ def test_show_save_errors(default_database, default_formatter, todo_factory):
         editor.left_column.body.contents[2].get_text()[0] ==
         'Time description not recognized: not a date'
     )
+
+
+@pytest.mark.parametrize('completed', [True, False])
+@pytest.mark.parametrize('check', [True, False])
+def test_save_completed(check, completed, default_formatter, todo_factory):
+    todo = todo_factory()
+    if completed:
+        todo.complete()
+    editor = TodoEditor(todo, [todo.list], default_formatter)
+
+    editor._completed.state = check
+    with pytest.raises(ExitMainLoop):
+        editor._keypress('ctrl s')
+    assert todo.is_completed is check

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -363,7 +363,7 @@ def show(ctx, id):
 def done(ctx, todos):
     """Mark one or more tasks as done."""
     for todo in todos:
-        todo.is_completed = True
+        todo.complete()
         ctx.db.save(todo)
         click.echo(ctx.formatter.detailed(todo))
 

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -45,11 +45,13 @@ class DefaultFormatter:
             if todo.due and todo.due <= self.now and not todo.is_completed:
                 due = click.style(due, fg='red')
 
+            recurring = '⟳' if todo.is_recurring else ''
+
             table.append([
                 todo.id,
                 "[{}]".format(completed),
                 priority,
-                due,
+                '{} {}'.format(due, recurring),
                 "{} {}{}".format(
                     todo.summary,
                     self.format_database(todo.list),

--- a/todoman/interactive.py
+++ b/todoman/interactive.py
@@ -166,7 +166,11 @@ class TodoEditor:
         self.todo.location = self.location
         self.todo.due = self.formatter.parse_datetime(self.due)
         self.todo.start = self.formatter.parse_datetime(self.dtstart)
-        self.todo.is_completed = self._completed.get_state()
+        if not self.todo.is_completed and self._completed.get_state():
+            self.todo.complete()
+        elif self.todo.is_completed and not self._completed.get_state():
+            self.todo.status = 'NEEDS-ACTION'
+            self.todo.completed_at = None
         self.todo.priority = self.priority
 
         # TODO: categories

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -280,8 +280,8 @@ class VtodoWritter:
         raise Exception('Unknown field {} serialized.'.format(name))
 
     def set_field(self, name, value):
-        if name in self.vtodo:
-            del(self.vtodo[name])
+        # If serialized value is None:
+        self.vtodo.pop(name)
         if value:
             logger.debug("Setting field %s to %s.", name, value)
             self.vtodo.add(name, value)
@@ -293,6 +293,7 @@ class VtodoWritter:
         self.vtodo = original
 
         for source, target in self.FIELD_MAP.items():
+            self.vtodo.pop(target)
             if getattr(self.todo, source):
                 self.set_field(
                     target,

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -195,18 +195,16 @@ class Todo:
             self.status in ('CANCELLED', 'COMPLETED')
         )
 
-    @is_completed.setter
-    def is_completed(self, val):
-        if val:
-            # Don't fiddle with completed_at if this was already completed:
-            if not self.is_completed:
-                self.completed_at = datetime.now(tz=LOCAL_TIMEZONE)
-            self.percent_complete = 100
-            self.status = 'COMPLETED'
-        else:
-            self.completed_at = None
-            self.percent_complete = None
-            self.status = 'NEEDS-ACTION'
+    def complete(self):
+        """
+        Immediately completes this todo
+
+        Immediately marks this todo as completed, sets the percentage to 100%
+        and the completed_at datetime to now.
+        """
+        self.completed_at = datetime.now(tz=LOCAL_TIMEZONE)
+        self.percent_complete = 100
+        self.status = 'COMPLETED'
 
     @cached_property
     def path(self):


### PR DESCRIPTION
Currently completing a recurring todo marks it as done, and future instances are lost forever.

This change allows completing a todo, and not losing future instances. Since the RFC is a bit grey on this aspect (eg: it doesn't support marking a single instance of a series as done, etc), we're imitating iOS's behaviour here, which is standards-compliant, and also does what a user would expect.

Fixes #17 