### PR TITLE
Pass arguments to the default command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,18 @@ releases, in reverse chronological order.
 v3.2.0
 ------
 
+New features
+~~~~~~~~~~~~
+
+* Allow passing arguments to the shortcut ``todo``, so ``todo --startable`` now
+  works as expected.
 * Completing recurring todos now works as expected and does not make if
   dissapear forever.
+
+Packaging changes
+~~~~~~~~~~~~~~~~~
+
+* New runtime dependency: ``click-default-group``.
 
 v3.1.0
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 atomicwrites
 click>=6.0
 click_log>=0.1.3
+click-default-group
 configobj
 humanize
 icalendar


### PR DESCRIPTION
Pass arguments to the default command so that stuff like `todo --startable` work.

Not sure if I want to merge this as-is, or actually contribute to click-default-group and make the default configurable. TBH, I with that I could make the group as a class, instead of a function with a bunch of decorators, but I don't know how much this is supported.