### PR TITLE
Fix parsing of requirements files by setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,18 +16,14 @@ setup(
             'todo = todoman.cli:cli',
         ]
     },
-    install_requires=[
-        open('requirements.txt').readlines()
-    ],
+    install_requires=open('requirements.txt').readlines(),
     long_description=open('README.rst').read(),
     use_scm_version={
         'version_scheme': 'post-release',
         'write_to': 'todoman/version.py',
     },
     setup_requires=['setuptools_scm != 1.12.0', 'pytest-runner'],
-    tests_require=[
-        open('requirements-dev.txt').readlines()
-    ],
+    tests_require=open('requirements-dev.txt').readlines(),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Something changed upstream and broke our requirements parsing. TBH,
though, it looks like our format was wrong all along.