### PR TITLE
Make --porcelain take precedence over config

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -883,3 +883,15 @@ def test_priority(runner):
     ])
 
     assert '!!!' in result.output
+
+
+def test_porcelain_precedence(runner, tmpdir):
+    """Test that --humanize flag takes precedence over `porcelain` config"""
+
+    path = tmpdir.join('config')
+    path.write('humanize = true\n', 'a')
+
+    with patch('todoman.formatters.PorcelainFormatter') as mocked_formatter:
+        runner.invoke(cli, ['--porcelain', 'list'])
+
+    assert mocked_formatter.call_count is 1

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -223,10 +223,10 @@ def cli(click_ctx, color, porcelain, humanize):
     if humanize is None:  # False means explicitly disabled
         humanize = ctx.config['main']['humanize']
 
-    if humanize:
-        ctx.formatter_class = formatters.HumanizedFormatter
-    elif porcelain:
+    if porcelain:
         ctx.formatter_class = formatters.PorcelainFormatter
+    elif humanize:
+        ctx.formatter_class = formatters.HumanizedFormatter
     else:
         ctx.formatter_class = formatters.DefaultFormatter
 


### PR DESCRIPTION
If humanize is set to true via the config, `--porcelain` is always ignored. CLI will now take precedence.