### PR TITLE
Narrow the scope of exceptions caught by the UI

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -143,3 +143,20 @@ def test_save_completed(check, completed, default_formatter, todo_factory):
     with pytest.raises(ExitMainLoop):
         editor._keypress('ctrl s')
     assert todo.is_completed is check
+
+
+def test_ctrl_c_clears(default_formatter, todo_factory):
+    todo = todo_factory()
+    editor = TodoEditor(todo, [todo.list], default_formatter)
+
+    # Simulate that ctrl+c gets pressed, since we can't *really* do that
+    # trivially inside unit tests.
+    with mock.patch(
+        'urwid.main_loop.MainLoop.run',
+        side_effect=KeyboardInterrupt
+    ), mock.patch(
+        'urwid.main_loop.MainLoop.stop',
+    ) as mocked_stop:
+        editor.edit()
+
+    assert mocked_stop.call_count == 1

--- a/todoman/interactive.py
+++ b/todoman/interactive.py
@@ -143,12 +143,8 @@ class TodoEditor:
         )
         try:
             self._loop.run()
-        except Exception:
-            try:  # Try to leave terminal in usable state
-                self._loop.stop()
-            except Exception:
-                pass
-            raise
+        except KeyboardInterrupt:
+            self._loop.stop()  # Try to leave terminal in usable state
         self._loop = None
 
     def _save(self, btn=None):


### PR DESCRIPTION
Only catch `KeyboardInterrupt`. If we see other exceptions (I don't think there are any that can bubble up right now), try to understand how they're raised and fix the cause.