### PR TITLE
Add initial support for (bash) autocompletion.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,5 +21,6 @@ Authors are listed in alphabetical order.
 * Paweł Fertyk <pfertyk@openmailbox.org>
 * Rimsha Khan <rimshakhan.rk03@gmail.com>
 * Sakshi Saraswat <saraswatsakshi.121@gmail.com>
+* Stephan Weller <stephan.weller@web.de>
 * Swati Garg <swati4star@gmail.com>
 * Thomas Glanzmann <thomas@glanzmann.de>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+v3.2.2
+------
+
+* Initial support for (bash) autocompletion.
+
 v3.2.1
 ------
 

--- a/contrib/completion/bash/_todo
+++ b/contrib/completion/bash/_todo
@@ -1,0 +1,94 @@
+_todo_single_dash_options()
+{
+	local prev_word=$1
+
+	case $prev_word in
+		copy)
+			echo "-l"
+			;;
+		edit)
+			echo "-s -d -i"
+			;;
+		list)
+			echo "-s"
+			;;
+		move)
+			echo "-l"
+			;;
+		new)
+			echo "-l -s -d -i"
+			;;
+		*)
+			echo "-v -h"
+		;;
+	esac
+}
+
+_todo_double_dash_options()
+{
+	local prev_word=$1
+
+	case $prev_word in
+		copy)
+			echo "--list"
+			;;
+		delete)
+			echo " --yes"
+			;;
+		edit)
+			echo " --start --due --location --interactive"
+			;;
+		flush)
+			echo " --yes"
+			;;
+		list)
+			echo " --location --category --grep --sort --reverse --no-reverse --due --priority --start --startable --status"
+			;;
+		move)
+			echo " --list"
+			;;
+		new)
+			echo " --list --start --due --location --interactive"
+			;;
+		show)
+		;;
+		*)
+			echo " --verbosity --color --colour --porcelain --humanize --version"
+		;;
+	esac
+
+	echo " --help"
+}
+
+_todo_complete()
+{
+	local cur_word prev_word arg_list
+
+	cur_word="${COMP_WORDS[COMP_CWORD]}"
+	prev_word="${COMP_WORDS[COMP_CWORD-1]}"
+	arg_list=""
+
+	if [[ ${cur_word} == --* ]] ; then
+		arg_list="$(_todo_double_dash_options ${prev_word})"
+	elif [[ ${cur_word} == -* ]] ; then
+		arg_list="$(_todo_single_dash_options ${prev_word}) $(_todo_double_dash_options ${prev_word})"
+	else
+		case ${prev_word} in
+			-v|--verbosity)
+				arg_list="CRITICAL ERROR WARNING INFO DEBUG"
+			;;
+			--color|--colour)
+				arg_list="always auto never"
+			;;
+			*)
+				arg_list="cancel copy delete done edit flush list move new show"
+			;;
+		esac
+	fi
+
+	COMPREPLY=( $(compgen -W "${arg_list}" -- ${cur_word}) )
+
+	return 0
+}
+
+complete -F _todo_complete todo

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,6 +31,36 @@ installation method::
 
     python3 setup.py install
 
+
+bash autocompletion (optional)
+------------------------------
+
+There is an autocompletion function for bash provided in the ``contrib``
+directory. If you want to enable autocompletion for todoman in bash, copy the
+file ``contrib/autocompletion/bash/_todo`` to any directory you want. Typically
+``/etc/bash_completion.d`` is used for system-wide installations or
+``~/.bash_completion.d`` for local installations. In the former case, the file
+is automatically sourced in most distributions, in the latter case, you will
+most likely need to add::
+
+    source ~/.bash_completion.d/_todo
+
+to your ``~/.bashrc``.
+
+
+zsh autocompletion (optional)
+-----------------------------
+
+There is no dedicated zsh completion function for todoman yet, but you can use
+the bash completion function via zsh's bash compatibility layer. This can be
+enabled. Assuming your completion function was copied to
+``~/.bash_completion.d`` as described above, you need to add the following
+lines to your ``~/.zshrc``::
+
+    autoload -U bashcompinit && bashcompinit
+    source ~/.bash_completion.d/*
+
+
 Requirements
 ------------
 


### PR DESCRIPTION
This should provide part of the fix for #187 (i.e. autocompletion for bash, but not yet for zsh).

Note that the completion is at the moment completely static. For the future, it would be great to add dynamic completion, e.g. if you type ``todo list --location <Tab>``, you would get all existing locations as completion options. However at the moment that would require parsing json from a bash script which is not so nice. Maybe we can add a ``--format`` switch to ``todo list`` in the future, so it is easy to list e.g. all locations from a bash script.