### PR TITLE
Fix start-up crash and drop click_log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+v3.2.1
+------
+
+* Fix start-up crash caused by click_log interface change.
+* Dropped runtime dependency: ``click_log``.
+
 v3.2.0
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 atomicwrites
 click>=6.0
-click_log>=0.1.3
 configobj
 humanize
 icalendar

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,13 +52,15 @@ def runner(config, sleep):
 @pytest.fixture
 def create(tmpdir):
     def inner(name, content, list_name='default'):
-        tmpdir.ensure_dir(list_name).join(name).write(
+        path = tmpdir.ensure_dir(list_name).join(name)
+        path.write(
             'BEGIN:VCALENDAR\n'
             'BEGIN:VTODO\n' +
             content +
             'END:VTODO\n'
             'END:VCALENDAR'
         )
+        return path
 
     return inner
 

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -1,13 +1,13 @@
 import functools
 import glob
 import locale
+import logging
 import sys
 from contextlib import contextmanager
 from datetime import timedelta
 from os.path import expanduser, isdir
 
 import click
-import click_log
 
 from todoman import exceptions, formatters
 from todoman.configuration import ConfigurationException, load_config
@@ -194,8 +194,13 @@ _interactive_option = click.option(
 
 
 @click.group(invoke_without_command=True)
-@click_log.init('todoman')
-@click_log.simple_verbosity_option()
+@click.option(
+    '-v',
+    '--verbosity',
+    type=click.Choice(['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']),
+    help='Set verbosity to the given level.',
+    default='WARNING',
+)
 @click.option('--colour', '--color', default=None,
               type=click.Choice(['always', 'auto', 'never']),
               help=('By default todoman will disable colored output if stdout '
@@ -209,7 +214,8 @@ _interactive_option = click.option(
 @click.pass_context
 @click.version_option(prog_name='todoman')
 @catch_errors
-def cli(click_ctx, color, porcelain, humanize):
+def cli(click_ctx, color, porcelain, humanize, verbosity):
+    logging.basicConfig(level=verbosity)
     ctx = click_ctx.ensure_object(AppContext)
     try:
         ctx.config = load_config()


### PR DESCRIPTION
Fix a crash caused by a change of interface in `click_log`.
Given that the new interface is a bit more verbose, and doesn't really add much to using base `logging`, I'll adhere with the latter.