### PR TITLE
Compensate for icalendars' the lack of VTIMEZONE

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,6 +9,14 @@ from freezegun import freeze_time
 from todoman.model import Todo, VtodoWritter
 
 
+def test_datetime_serialization(todo_factory, tmpdir):
+    now = datetime(2017, 8, 31, 23, 49, 53, tzinfo=pytz.UTC)
+    todo = todo_factory(created_at=now)
+    filename = tmpdir.join('default').join(todo.filename)
+    with open(filename) as f:
+        assert 'CREATED;VALUE=DATE-TIME:20170831T234953Z\n' in f.readlines()
+
+
 def test_serialize_created_at(todo_factory):
     now = datetime.now(tz=pytz.UTC)
     todo = todo_factory(created_at=now)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -13,7 +13,7 @@ def test_datetime_serialization(todo_factory, tmpdir):
     now = datetime(2017, 8, 31, 23, 49, 53, tzinfo=pytz.UTC)
     todo = todo_factory(created_at=now)
     filename = tmpdir.join('default').join(todo.filename)
-    with open(filename) as f:
+    with open(str(filename)) as f:
         assert 'CREATED;VALUE=DATE-TIME:20170831T234953Z\n' in f.readlines()
 
 

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -7,6 +7,7 @@ from os.path import normpath, split
 from uuid import uuid4
 
 import icalendar
+import pytz
 from atomicwrites import AtomicWriter
 from dateutil.rrule import rrulestr
 from dateutil.tz import tzlocal
@@ -276,6 +277,11 @@ class VtodoWritter:
 
         - Convert everything to datetime
         - Add missing timezones
+        - Cast to UTC
+
+        Datetimes are cast to UTC because icalendar doesn't include the
+        VTIMEZONE information upon serialization, and some clients have issues
+        dealing with that.
         '''
         if isinstance(dt, date) and not isinstance(dt, datetime):
             dt = datetime(dt.year, dt.month, dt.day)
@@ -283,7 +289,7 @@ class VtodoWritter:
         if not dt.tzinfo:
             dt = dt.replace(tzinfo=LOCAL_TIMEZONE)
 
-        return dt
+        return dt.astimezone(pytz.UTC)
 
     def serialize_field(self, name, value):
         if name in Todo.RRULE_FIELDS:


### PR DESCRIPTION
icalendar doesn't output a VTIMEZONE for non-UTC timezones, and some clients fail to parse this.

To work around this, cast all datetimes to UTC upon serialization.

Fixes #263 