### PR TITLE
Skip tests that're incompatible with PyICU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ matrix:
       python: 3.6
       after_install:
         - echo click_repl >> requirements.txt
+    - # Run tests with incompatible test dependencies:
+      python: 3.6
+      after_install:
+        - echo pyicu >> requirements.txt
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,12 @@ matrix:
       python: 3.6
       after_install:
         - echo click_repl >> requirements.txt
+      env: TOXENV=py EXTRAS=click_repl
     - # Run tests with incompatible test dependencies:
       python: 3.6
       after_install:
         - echo pyicu >> requirements.txt
+      env: TOXENV=py EXTRAS=pyicu
 
 addons:
   apt:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,20 @@
+__all__ = [
+    'pyicu_sensitive',
+]
+
+import pytest
+
+
+def is_pyicu_installed():
+    try:
+        import icu  # noqa: F401: This is an import to tests if it's installed.
+    except ImportError:
+        return False
+    else:
+        return True
+
+
+pyicu_sensitive = pytest.mark.skipif(
+    is_pyicu_installed(),
+    reason="This test cannot be run with pyicu installed.",
+)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from dateutil.tz import tzlocal
 from freezegun import freeze_time
 from hypothesis import given
 
+from tests.helpers import pyicu_sensitive
 from todoman.cli import cli, exceptions
 from todoman.model import Database, Todo
 
@@ -209,6 +210,7 @@ def test_move(tmpdir, runner, create):
     assert 'other_list' in result.output
 
 
+@pyicu_sensitive
 @freeze_time('2017-03-17 20:22:19')
 def test_dtstamp(tmpdir, runner, create):
     """Test that we add the DTSTAMP to new entries as per RFC5545."""
@@ -263,6 +265,7 @@ def test_default_due(
         )
 
 
+@pyicu_sensitive
 @freeze_time(datetime.datetime.now())
 def test_default_due2(tmpdir, runner, create, todos):
     cfg = tmpdir.join('config')
@@ -644,6 +647,7 @@ def test_todo_edit(runner, default_database, todo_factory):
     assert 'YARR!' in result.output
 
 
+@pyicu_sensitive
 @freeze_time('2017, 3, 20')
 def test_list_startable(tmpdir, runner, todo_factory):
     todo_factory(summary='started', start=datetime.datetime(2017, 3, 15))

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -4,10 +4,12 @@ import pytest
 import pytz
 from freezegun import freeze_time
 
+from tests.helpers import pyicu_sensitive
 from todoman.cli import cli
 from todoman.formatters import rgb_to_ansi
 
 
+@pyicu_sensitive
 @pytest.mark.parametrize('interval', [
     (65, 'in a minute'),
     (-10800, '3 hours ago'),


### PR DESCRIPTION
Some tests fail to run if PyICU is installed (it seems to break compatibility across a few test dependencies, nothing we use outside of tests directly).

Skip those if PyICU is installed. This is mostly for downstream packagers running tests, or possibly some developers that have PyICU installed locally.

Closes #119; the underlying upstream issue has been reported [here](https://github.com/spulec/freezegun/issues/207)