### PR TITLE
Explicitly define which PyPI endpoint to push to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ deploy:
     on:
       tags: true
     distributions: "sdist bdist_wheel"
+    server: https://upload.pypi.org/legacy/
   - provider: releases
     api_key:
       secure: g60yeYa+BX7XCe7L4mpV5NiaCPkuJzxk+PP3rL/durPF/CudWW2xUuTCLf30WwfrYBg3bJCQKNnzOpL8+d4Maly3UqquDFjK58Z/JBFw6erzg/RAxAnfJzFbWy2mgqKTpBHaDdRnhVtqp23Ov1I/+Jb51DIhij6ILNgGxW1OP8Y=


### PR DESCRIPTION
Pushes have been failing lately (and not just taking a few hours/days to
finish as they used to).

It's most likely due to this:
* https://mail.python.org/pipermail/distutils-sig/2017-June/030766.html
* https://packaging.python.org/guides/migrating-to-pypi-org/#uploading
* https://github.com/pypa/warehouse/issues/2342