### PR TITLE
Reformat using yapf, and add it to CI

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ config = ConfigObj(
     None,
     configspec=specpath,
     stringify=False,
-    list_values=False
+    list_values=False,
 )
 validator = validate.Validator()
 config.validate(validator)
@@ -52,7 +52,9 @@ def write_section(section, secname, key, comment, file_):
         fun_args = []
     if fun_name == 'integer' and len(fun_args) == 2:
         fun_name += ', allowed values are between {} and {}'.format(
-            fun_args[0], fun_args[1])
+            fun_args[0],
+            fun_args[1],
+        )
         fun_args = []
     file_.write('\n')
     if fun_name in ['expand_db_path', 'expand_path']:
@@ -89,8 +91,13 @@ with open('confspec.tmp', 'w') as file_:
                 file_.write('\n')
                 comments = spec[secname]['__many__'].comments
                 for key, comment in sorted(comments.items()):
-                    write_section(spec[secname]['__many__'][key], secname,
-                                  key, comment, file_)
+                    write_section(
+                        spec[secname]['__many__'][key],
+                        secname,
+                        key,
+                        comment,
+                        file_,
+                    )
             else:
                 write_section(spec[secname][key], secname, key, comment, file_)
 
@@ -180,7 +187,6 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -314,8 +320,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'Todoman.tex', 'Todoman Documentation',
-   'Hugo Osvaldo Barrera', 'manual'),
+    (
+        master_doc,
+        'Todoman.tex',
+        'Todoman Documentation',
+        'Hugo Osvaldo Barrera',
+        'manual',
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -338,19 +349,20 @@ latex_documents = [
 # If false, no module index is generated.
 #  latex_domain_indices = True
 
-
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'todoman', 'Todoman Documentation',
-     [author], 1)
-]
+man_pages = [(
+    master_doc,
+    'todoman',
+    'Todoman Documentation',
+    [author],
+    1,
+)]
 
 # If true, show URL addresses after external links.
 #  man_show_urls = False
-
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -358,9 +370,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'Todoman', 'Todoman Documentation',
-   author, 'Todoman', 'One line description of project.',
-   'Miscellaneous'),
+    (
+        master_doc,
+        'Todoman',
+        'Todoman Documentation',
+        author,
+        'Todoman',
+        'One line description of project.',
+        'Miscellaneous',
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,9 @@ test=pytest
 [tool:pytest]
 testpaths = tests
 addopts = --cov=todoman --cov-report=term-missing
+
+[yapf]
+coalesce_brackets = true
+dedent_closing_brackets = true
+space_between_ending_comma_and_closing_bracket = false
+split_arguments_when_comma_terminated = true

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     entry_points={
         'console_scripts': [
             'todo = todoman.cli:cli',
-        ]
+        ],
     },
     install_requires=open('requirements.txt').readlines(),
     long_description=open('README.rst').read(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,29 +24,29 @@ def default_database(tmpdir):
 @pytest.fixture
 def config(tmpdir, default_database):
     path = tmpdir.join('config')
-    path.write('[main]\n'
-               'path = {}/*\n'
-               'date_format = %Y-%m-%d\n'
-               'time_format = \n'
-               'cache_path = {}\n'
-               .format(str(tmpdir), str(tmpdir.join('cache.sqlite3'))))
+    path.write(
+        '[main]\n'
+        'path = {}/*\n'
+        'date_format = %Y-%m-%d\n'
+        'time_format = \n'
+        'cache_path = {}\n'
+        .format(str(tmpdir), str(tmpdir.join('cache.sqlite3')))
+    )
     return path
 
 
 @pytest.fixture
 def runner(config, sleep):
-
     class SleepyCliRunner(CliRunner):
         """
         Sleeps before invoking to make sure cache entries have expired.
         """
+
         def invoke(self, *args, **kwargs):
             sleep()
             return super().invoke(*args, **kwargs)
 
-    return SleepyCliRunner(env={
-        'TODOMAN_CONFIG': str(config)
-    })
+    return SleepyCliRunner(env={'TODOMAN_CONFIG': str(config)})
 
 
 @pytest.fixture
@@ -55,9 +55,7 @@ def create(tmpdir):
         path = tmpdir.ensure_dir(list_name).join(name)
         path.write(
             'BEGIN:VCALENDAR\n'
-            'BEGIN:VTODO\n' +
-            content +
-            'END:VTODO\n'
+            'BEGIN:VTODO\n' + content + 'END:VTODO\n'
             'END:VCALENDAR'
         )
         return path
@@ -67,7 +65,6 @@ def create(tmpdir):
 
 @pytest.fixture
 def now_for_tz():
-
     def inner(tz='CET'):
         """
         Provides the current time cast to a given timezone.
@@ -155,7 +152,6 @@ def sleep(tmpdir_factory):
 
 @pytest.fixture
 def todos(default_database, sleep):
-
     def inner(**filters):
         sleep()
         default_database.update_cache()
@@ -164,14 +160,15 @@ def todos(default_database, sleep):
     return inner
 
 
-settings.register_profile("ci", settings(
-    max_examples=1000,
-    verbosity=Verbosity.verbose,
-    suppress_health_check=[HealthCheck.too_slow]
-))
-settings.register_profile("deterministic", settings(
-    derandomize=True,
-))
+settings.register_profile(
+    "ci",
+    settings(
+        max_examples=1000,
+        verbosity=Verbosity.verbose,
+        suppress_health_check=[HealthCheck.too_slow]
+    )
+)
+settings.register_profile("deterministic", settings(derandomize=True,))
 
 if os.getenv('DETERMINISTIC_TESTS', 'false').lower() == 'true':
     settings.load_profile("deterministic")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -92,20 +92,22 @@ def test_sequence_increment(default_database, todo_factory, todos):
 def test_normalize_datetime():
     writter = VtodoWritter(None)
     assert (
-        writter.normalize_datetime(date(2017, 6, 17)) ==
-        datetime(2017, 6, 17, tzinfo=tzlocal())
+        writter.normalize_datetime(date(2017, 6, 17)) == datetime(
+            2017, 6, 17, tzinfo=tzlocal()
+        )
     )
     assert (
-        writter.normalize_datetime(datetime(2017, 6, 17)) ==
-        datetime(2017, 6, 17, tzinfo=tzlocal())
+        writter.normalize_datetime(datetime(2017, 6, 17)) == datetime(
+            2017, 6, 17, tzinfo=tzlocal()
+        )
     )
     assert (
-        writter.normalize_datetime(datetime(2017, 6, 17, 12, 19)) ==
-        datetime(2017, 6, 17, 12, 19, tzinfo=tzlocal())
+        writter.normalize_datetime(datetime(2017, 6, 17, 12, 19)) == datetime(
+            2017, 6, 17, 12, 19, tzinfo=tzlocal()
+        )
     )
     assert (
         writter.normalize_datetime(
             datetime(2017, 6, 17, 12, tzinfo=tzlocal())
-        ) ==
-        datetime(2017, 6, 17, 12, tzinfo=tzlocal())
+        ) == datetime(2017, 6, 17, 12, tzinfo=tzlocal())
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,10 +23,7 @@ def test_list(tmpdir, runner, create):
     assert not result.exception
     assert not result.output.strip()
 
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n')
     result = runner.invoke(cli, ['list'])
     assert not result.exception
     assert 'harhar' in result.output
@@ -36,8 +33,10 @@ def test_no_default_list(runner):
     result = runner.invoke(cli, ['new', 'Configure a default list'])
 
     assert result.exception
-    assert ('Error: Invalid value for "--list" / "-l": You must set '
-            '"default_list" or use -l.' in result.output)
+    assert (
+        'Error: Invalid value for "--list" / "-l": You must set '
+        '"default_list" or use -l.' in result.output
+    )
 
 
 def test_no_extra_whitespace(tmpdir, runner, create):
@@ -54,21 +53,14 @@ def test_no_extra_whitespace(tmpdir, runner, create):
     assert not result.exception
     assert result.output == '\n'
 
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n')
     result = runner.invoke(cli, ['list'])
     assert not result.exception
     assert len(result.output.splitlines()) == 1
 
 
 def test_percent(tmpdir, runner, create):
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-        'PERCENT-COMPLETE:78\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n' 'PERCENT-COMPLETE:78\n')
     result = runner.invoke(cli, ['list'])
     assert not result.exception
     assert '78%' in result.output
@@ -81,11 +73,7 @@ def test_list_inexistant(tmpdir, runner, create):
 
 
 def test_show_existing(tmpdir, runner, create):
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-        'DESCRIPTION:Lots of text. Yum!\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n' 'DESCRIPTION:Lots of text. Yum!\n')
     result = runner.invoke(cli, ['list'])
     result = runner.invoke(cli, ['show', '1'])
     assert not result.exception
@@ -94,10 +82,7 @@ def test_show_existing(tmpdir, runner, create):
 
 
 def test_show_inexistant(tmpdir, runner, create):
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n')
     result = runner.invoke(cli, ['list'])
     result = runner.invoke(cli, ['show', '2'])
     assert result.exit_code == 20
@@ -105,9 +90,9 @@ def test_show_inexistant(tmpdir, runner, create):
 
 
 def test_human(runner):
-    result = runner.invoke(cli, [
-        'new', '-l', 'default', '-d', 'tomorrow', 'hail belzebub'
-    ])
+    result = runner.invoke(
+        cli, ['new', '-l', 'default', '-d', 'tomorrow', 'hail belzebub']
+    )
     assert not result.exception
     assert 'belzebub' in result.output
 
@@ -136,20 +121,14 @@ def test_two_events(tmpdir, runner):
 
 
 def test_default_command(tmpdir, runner, create):
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n')
     result = runner.invoke(cli)
     assert not result.exception
     assert 'harhar' in result.output
 
 
 def test_delete(runner, create):
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n')
     result = runner.invoke(cli, ['list'])
     assert not result.exception
     result = runner.invoke(cli, ['delete', '1', '--yes'])
@@ -172,10 +151,7 @@ def test_delete_prompt(todo_factory, runner, todos):
 
 def test_copy(tmpdir, runner, create):
     tmpdir.mkdir('other_list')
-    create(
-        'test.ics',
-        'SUMMARY:test_copy\n'
-    )
+    create('test.ics', 'SUMMARY:test_copy\n')
     result = runner.invoke(cli, ['list'])
     assert not result.exception
     assert 'test_copy' in result.output
@@ -192,10 +168,7 @@ def test_copy(tmpdir, runner, create):
 
 def test_move(tmpdir, runner, create):
     tmpdir.mkdir('other_list')
-    create(
-        'test.ics',
-        'SUMMARY:test_move\n'
-    )
+    create('test.ics', 'SUMMARY:test_move\n')
     result = runner.invoke(cli, ['list'])
     assert not result.exception
     assert 'test_move' in result.output
@@ -217,8 +190,7 @@ def test_dtstamp(tmpdir, runner, create):
     result = runner.invoke(cli, ['new', '-l', 'default', 'test event'])
     assert not result.exception
 
-    db = Database([tmpdir.join('default')],
-                  tmpdir.join('/dtstamp_cache'))
+    db = Database([tmpdir.join('default')], tmpdir.join('/dtstamp_cache'))
     todo = list(db.todos())[0]
     assert todo.dtstamp is not None
     assert todo.dtstamp == datetime.datetime.now(tz=tzlocal())
@@ -235,8 +207,7 @@ def test_default_list(tmpdir, runner, create):
     result = runner.invoke(cli, ['new', 'test default list'])
     assert not result.exception
 
-    db = Database([tmpdir.join('default')],
-                  tmpdir.join('/default_list'))
+    db = Database([tmpdir.join('default')], tmpdir.join('/default_list'))
     todo = list(db.todos())[0]
     assert todo.summary == 'test default list'
 
@@ -245,9 +216,7 @@ def test_default_list(tmpdir, runner, create):
     'default_due, expected_due_hours', [(None, 24), (1, 1), (0, None)],
     ids=['not specified', 'greater than 0', '0']
 )
-def test_default_due(
-    tmpdir, runner, create, default_due, expected_due_hours
-):
+def test_default_due(tmpdir, runner, create, default_due, expected_due_hours):
     """Test setting the due date using the default_due config parameter"""
     if default_due is not None:
         path = tmpdir.join('config')
@@ -312,10 +281,12 @@ def test_sorting_fields(tmpdir, runner, default_database):
         'categories',
     )
 
-    @given(sort_key=st.lists(
-        st.sampled_from(fields + tuple('-' + x for x in fields)),
-        unique=True
-    ))
+    @given(
+        sort_key=st.lists(
+            st.sampled_from(fields + tuple('-' + x for x in fields)),
+            unique=True
+        )
+    )
     def run_test(sort_key):
         sort_key = ','.join(sort_key)
         result = runner.invoke(cli, ['list', '--sort', sort_key])
@@ -328,20 +299,15 @@ def test_sorting_fields(tmpdir, runner, default_database):
 
 def test_sorting_output(tmpdir, runner, create):
     create(
-        'test.ics',
-        'SUMMARY:aaa\n'
+        'test.ics', 'SUMMARY:aaa\n'
         'DUE;VALUE=DATE-TIME;TZID=ART:20160102T000000\n'
     )
     create(
-        'test2.ics',
-        'SUMMARY:bbb\n'
+        'test2.ics', 'SUMMARY:bbb\n'
         'DUE;VALUE=DATE-TIME;TZID=ART:20160101T000000\n'
     )
 
-    examples = [
-        ('-summary', ['aaa', 'bbb']),
-        ('due', ['aaa', 'bbb'])
-    ]
+    examples = [('-summary', ['aaa', 'bbb']), ('due', ['aaa', 'bbb'])]
 
     # Normal sorting, reversed by default
     all_examples = [(['--sort', key], order) for key, order in examples]
@@ -363,14 +329,9 @@ def test_sorting_output(tmpdir, runner, create):
 
 
 def test_sorting_null_values(tmpdir, runner, create):
+    create('test.ics', 'SUMMARY:aaa\n' 'PRIORITY:9\n')
     create(
-        'test.ics',
-        'SUMMARY:aaa\n'
-        'PRIORITY:9\n'
-    )
-    create(
-        'test2.ics',
-        'SUMMARY:bbb\n'
+        'test2.ics', 'SUMMARY:bbb\n'
         'DUE;VALUE=DATE-TIME;TZID=ART:20160101T000000\n'
     )
 
@@ -391,8 +352,7 @@ def test_sort_invalid_fields(runner):
 def test_color_due_dates(tmpdir, runner, create, hours):
     due = datetime.datetime.now() + datetime.timedelta(hours=hours)
     create(
-        'test.ics',
-        'SUMMARY:aaa\n'
+        'test.ics', 'SUMMARY:aaa\n'
         'STATUS:IN-PROCESS\n'
         'DUE;VALUE=DATE-TIME;TZID=ART:{}\n'
         .format(due.strftime('%Y%m%dT%H%M%S'))
@@ -414,21 +374,18 @@ def test_color_flag(runner, todo_factory):
     todo_factory(due=datetime.datetime(2007, 3, 22))
 
     result = runner.invoke(cli, ['--color', 'always'], color=True)
-    assert(
+    assert (
         result.output.strip() ==
         '1  [ ]    \x1b[31m2007-03-22\x1b[0m  YARR! @default\x1b[0m'
     )
     result = runner.invoke(cli, color=True)
-    assert(
+    assert (
         result.output.strip() ==
         '1  [ ]    \x1b[31m2007-03-22\x1b[0m  YARR! @default\x1b[0m'
     )
 
     result = runner.invoke(cli, ['--color', 'never'], color=True)
-    assert(
-        result.output.strip() ==
-        '1  [ ]    2007-03-22  YARR! @default'
-    )
+    assert (result.output.strip() == '1  [ ]    2007-03-22  YARR! @default')
 
 
 def test_flush(tmpdir, runner, create, todo_factory, todos):
@@ -522,27 +479,25 @@ def test_empty_list(tmpdir, runner, create):
             item.remove()
 
     result = runner.invoke(cli)
-    expected = ("No lists found matching {}/*, create"
-                " a directory for a new list").format(tmpdir)
+    expected = (
+        "No lists found matching {}/*, create"
+        " a directory for a new list"
+    ).format(tmpdir)
 
     assert expected in result.output
 
 
 def test_show_location(tmpdir, runner, create):
-    create(
-        'test.ics',
-        'SUMMARY:harhar\n'
-        'LOCATION:Boston\n'
-    )
+    create('test.ics', 'SUMMARY:harhar\n' 'LOCATION:Boston\n')
 
     result = runner.invoke(cli, ['show', '1'])
     assert 'Boston' in result.output
 
 
 def test_location(runner):
-    result = runner.invoke(cli, [
-        'new', '-l', 'default', '--location', 'Chembur', 'Event Test'
-    ])
+    result = runner.invoke(
+        cli, ['new', '-l', 'default', '--location', 'Chembur', 'Event Test']
+    )
 
     assert 'Chembur' in result.output
 
@@ -593,8 +548,7 @@ def test_due_bad_date(runner):
 
 def test_multiple_todos_in_file(runner, create):
     path = create(
-        'test.ics',
-        'SUMMARY:a\n'
+        'test.ics', 'SUMMARY:a\n'
         'END:VTODO\n'
         'BEGIN:VTODO\n'
         'SUMMARY:b\n'
@@ -757,9 +711,7 @@ def test_cancel(runner, todo_factory, todos):
 
 
 def test_id_printed_for_new(runner):
-    result = runner.invoke(cli, [
-        'new', '-l', 'default', 'show me an id'
-    ])
+    result = runner.invoke(cli, ['new', '-l', 'default', 'show me an id'])
     assert not result.exception
     assert result.output.strip().startswith('1')
 
@@ -793,12 +745,14 @@ def test_no_repl(runner):
 def test_status_validation():
     from todoman import cli
 
-    @given(statuses=st.lists(
-        st.sampled_from(Todo.VALID_STATUSES + ('ANY',)),
-        min_size=1,
-        max_size=5,
-        unique=True
-    ))
+    @given(
+        statuses=st.lists(
+            st.sampled_from(Todo.VALID_STATUSES + ('ANY',)),
+            min_size=1,
+            max_size=5,
+            unique=True
+        )
+    )
     def run_test(statuses):
         validated = cli.validate_status(val=','.join(statuses))
 
@@ -829,7 +783,7 @@ def test_status_filtering(runner, todo_factory):
     result = runner.invoke(cli, ['list', '--status', 'cancelled'])
     assert not result.exception
     assert len(result.output.splitlines()) == 1
-    assert 'one 'in result.output
+    assert 'one ' in result.output
 
     result = runner.invoke(cli, ['list', '--status', 'NEEDS-action'])
     assert not result.exception
@@ -870,9 +824,9 @@ def test_show_priority(runner, todo_factory, todos):
 
 
 def test_priority(runner):
-    result = runner.invoke(cli, [
-        'new', '-l', 'default', '--priority', 'high', 'Priority Test'
-    ])
+    result = runner.invoke(
+        cli, ['new', '-l', 'default', '--priority', 'high', 'Priority Test']
+    )
 
     assert '!!!' in result.output
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,11 +56,7 @@ def test_sane_config(config, runner, tmpdir):
 
 
 def test_invalid_color(config, runner):
-    config.write(
-        '[main]\n'
-        'color = 12\n'
-        'path = "/"\n'
-    )
+    config.write('[main]\n' 'color = 12\n' 'path = "/"\n')
     result = runner.invoke(cli, ['list'])
     assert result.exception
     assert 'Error: Bad color setting, the value "12" is unacceptable.' \
@@ -68,24 +64,20 @@ def test_invalid_color(config, runner):
 
 
 def test_invalid_color_arg(config, runner):
-    config.write(
-        '[main]\n'
-        'path = "/"\n'
-    )
+    config.write('[main]\n' 'path = "/"\n')
     result = runner.invoke(cli, ['--color', '12', 'list'])
     assert result.exception
     assert 'Usage:' in result.output
 
 
 def test_missing_path(config, runner):
-    config.write(
-        '[main]\n'
-        'color = auto\n'
-    )
+    config.write('[main]\n' 'color = auto\n')
     result = runner.invoke(cli, ['list'])
     assert result.exception
-    assert ("Error: path is missing from the ['main'] section of the "
-            "configuration file") in result.output
+    assert (
+        "Error: path is missing from the ['main'] section of the "
+        "configuration file"
+    ) in result.output
 
 
 @pytest.mark.xfail(reason="Not implemented")
@@ -122,10 +114,11 @@ def test_missing_cache_dir(config, runner, tmpdir):
 
     path = tmpdir.join('config')
     path.write('cache_path = {}\n'.format(cache_file), 'a')
-    path.write('[main]\n'
-               'path = {}/*\n'
-               'cache_path = {}\n'
-               .format(str(tmpdir), cache_file))
+    path.write(
+        '[main]\n'
+        'path = {}/*\n'
+        'cache_path = {}\n'.format(str(tmpdir), cache_file)
+    )
 
     result = runner.invoke(cli)
     assert not result.exception
@@ -134,11 +127,7 @@ def test_missing_cache_dir(config, runner, tmpdir):
 
 
 def test_date_field_in_time_format(config, runner, tmpdir):
-    config.write(
-        '[main]\n'
-        'path = "/"\n'
-        'time_format = %Y-%m-%d\n'
-    )
+    config.write('[main]\n' 'path = "/"\n' 'time_format = %Y-%m-%d\n')
     result = runner.invoke(cli)
     assert result.exception
     assert (
@@ -148,11 +137,7 @@ def test_date_field_in_time_format(config, runner, tmpdir):
 
 
 def test_date_field_in_time(config, runner, tmpdir):
-    config.write(
-        '[main]\n'
-        'path = "/"\n'
-        'date_format = %Y-%d-:%M\n'
-    )
+    config.write('[main]\n' 'path = "/"\n' 'date_format = %Y-%d-:%M\n')
     result = runner.invoke(cli)
     assert result.exception
     assert (

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -9,25 +9,10 @@ def test_priority(tmpdir, runner, create):
     assert not result.exception
     assert not result.output.strip()
 
-    create(
-        'one.ics',
-        'SUMMARY:haha\n'
-        'PRIORITY:4\n'
-    )
-    create(
-        'two.ics',
-        'SUMMARY:hoho\n'
-        'PRIORITY:9\n'
-    )
-    create(
-        'three.ics',
-        'SUMMARY:hehe\n'
-        'PRIORITY:5\n'
-    )
-    create(
-        'four.ics',
-        'SUMMARY:huhu\n'
-    )
+    create('one.ics', 'SUMMARY:haha\n' 'PRIORITY:4\n')
+    create('two.ics', 'SUMMARY:hoho\n' 'PRIORITY:9\n')
+    create('three.ics', 'SUMMARY:hehe\n' 'PRIORITY:5\n')
+    create('four.ics', 'SUMMARY:huhu\n')
 
     result_high = runner.invoke(cli, ['list', '--priority=high'])
     assert not result_high.exception
@@ -66,20 +51,9 @@ def test_location(tmpdir, runner, create):
     assert not result.exception
     assert not result.output.strip()
 
-    create(
-        'one.ics',
-        'SUMMARY:haha\n'
-        'LOCATION: The Pool\n'
-    )
-    create(
-        'two.ics',
-        'SUMMARY:hoho\n'
-        'LOCATION: The Dungeon\n'
-    )
-    create(
-        'two.ics',
-        'SUMMARY:harhar\n'
-    )
+    create('one.ics', 'SUMMARY:haha\n' 'LOCATION: The Pool\n')
+    create('two.ics', 'SUMMARY:hoho\n' 'LOCATION: The Dungeon\n')
+    create('two.ics', 'SUMMARY:harhar\n')
     result = runner.invoke(cli, ['list', '--location', 'Pool'])
     assert not result.exception
     assert 'haha' in result.output
@@ -92,20 +66,9 @@ def test_category(tmpdir, runner, create):
     assert not result.exception
     assert not result.output.strip()
 
-    create(
-        'one.ics',
-        'SUMMARY:haha\n'
-        'CATEGORIES:work,trip\n'
-    )
-    create(
-        'two.ics',
-        'CATEGORIES:trip\n'
-        'SUMMARY:hoho\n'
-    )
-    create(
-        'three.ics',
-        'SUMMARY:harhar\n'
-    )
+    create('one.ics', 'SUMMARY:haha\n' 'CATEGORIES:work,trip\n')
+    create('two.ics', 'CATEGORIES:trip\n' 'SUMMARY:hoho\n')
+    create('three.ics', 'SUMMARY:harhar\n')
     result = runner.invoke(cli, ['list', '--category', 'work'])
     assert not result.exception
     assert 'haha' in result.output
@@ -143,10 +106,7 @@ def test_grep(tmpdir, runner, create):
         'SUMMARY:research\n'
         'DESCRIPTION: Cure cancer\n',
     )
-    create(
-        'six.ics',
-        'SUMMARY:hoho\n'
-    )
+    create('six.ics', 'SUMMARY:hoho\n')
     result = runner.invoke(cli, ['list', '--grep', 'fun'])
     assert not result.exception
     assert 'fun' in result.output
@@ -203,10 +163,10 @@ def test_due_naive(tmpdir, runner, create):
     for i in [1, 23, 25, 48]:
         due = now + timedelta(hours=i)
         create(
-            'test_{}.ics'.format(i),
-            'SUMMARY:{}\n'
+            'test_{}.ics'.format(i), 'SUMMARY:{}\n'
             'DUE;VALUE=DATE-TIME:{}\n'.format(
-                i, due.strftime("%Y%m%dT%H%M%S"),
+                i,
+                due.strftime("%Y%m%dT%H%M%S"),
             )
         )
 
@@ -273,13 +233,10 @@ def test_statuses(todo_factory, todos):
     in_process_todos = set(todos(status=['IN-PROCESS']))
     needs_action_todos = set(todos(status=['NEEDS-ACTION']))
 
-    assert {t.uid for t in all_todos} == {
-        cancelled,
-        completed,
-        in_process,
-        needs_action,
-        no_status
-    }
+    assert {t.uid
+            for t in all_todos} == {
+                cancelled, completed, in_process, needs_action, no_status
+            }
     assert {t.uid for t in cancelled_todos} == {cancelled}
     assert {t.uid for t in completed_todos} == {completed}
     assert {t.uid for t in in_process_todos} == {in_process}

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -10,18 +10,19 @@ from todoman.formatters import rgb_to_ansi
 
 
 @pyicu_sensitive
-@pytest.mark.parametrize('interval', [
-    (65, 'in a minute'),
-    (-10800, '3 hours ago'),
-])
+@pytest.mark.parametrize(
+    'interval', [
+        (65, 'in a minute'),
+        (-10800, '3 hours ago'),
+    ]
+)
 @pytest.mark.parametrize('tz', ['CET', 'HST'])
 @freeze_time('2017-03-25')
 def test_humanized_date(runner, create, interval, now_for_tz, tz):
     seconds, expected = interval
     due = now_for_tz(tz) + timedelta(seconds=seconds)
     create(
-        'test.ics',
-        'SUMMARY:Hi human!\n'
+        'test.ics', 'SUMMARY:Hi human!\n'
         'DUE;VALUE=DATE-TIME;TZID={}:{}\n'
         .format(tz, due.strftime('%Y%m%dT%H%M%S'))
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,9 @@ def test_main(tmpdir, runner):
     cli_result = runner.invoke(cli, ['--version'])
 
     pipe = Popen(
-        [sys.executable, '-m', 'todoman', '--version'], stdout=PIPE, env=env
+        [sys.executable, '-m', 'todoman', '--version'],
+        stdout=PIPE,
+        env=env,
     )
     main_output = pipe.communicate()[0]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,10 +21,8 @@ def test_querying(create, tmpdir):
                 list_name=list
             )
 
-    db = Database(
-        [str(tmpdir.ensure_dir(l)) for l in 'abc'],
-        str(tmpdir.join('cache'))
-    )
+    db = Database([str(tmpdir.ensure_dir(l)) for l in 'abc'],
+                  str(tmpdir.join('cache')))
 
     assert len(set(db.todos())) == 9
     assert len(set(db.todos(lists='ab'))) == 6
@@ -33,13 +31,11 @@ def test_querying(create, tmpdir):
 
 def test_retain_tz(tmpdir, create, todos):
     create(
-        'ar.ics',
-        'SUMMARY:blah.ar\n'
+        'ar.ics', 'SUMMARY:blah.ar\n'
         'DUE;VALUE=DATE-TIME;TZID=HST:20160102T000000\n'
     )
     create(
-        'de.ics',
-        'SUMMARY:blah.de\n'
+        'de.ics', 'SUMMARY:blah.de\n'
         'DUE;VALUE=DATE-TIME;TZID=CET:20160102T000000\n'
     )
 
@@ -55,11 +51,7 @@ def test_retain_tz(tmpdir, create, todos):
 
 
 def test_due_date(tmpdir, create, todos):
-    create(
-        'ar.ics',
-        'SUMMARY:blah.ar\n'
-        'DUE;VALUE=DATE:20170617\n'
-    )
+    create('ar.ics', 'SUMMARY:blah.ar\n' 'DUE;VALUE=DATE:20170617\n')
 
     todos = list(todos())
 
@@ -120,14 +112,8 @@ def test_list_no_colour(tmpdir):
 
 def test_database_priority_sorting(create, todos):
     for i in [1, 5, 9, 0]:
-        create(
-            'test{}.ics'.format(i),
-            'PRIORITY:{}\n'.format(i)
-        )
-    create(
-        'test_none.ics'.format(i),
-        'SUMMARY:No priority (eg: None)\n'
-    )
+        create('test{}.ics'.format(i), 'PRIORITY:{}\n'.format(i))
+    create('test_none.ics'.format(i), 'SUMMARY:No priority (eg: None)\n')
 
     todos = list(todos())
 
@@ -143,8 +129,7 @@ def test_retain_unknown_fields(tmpdir, create, default_database):
     Test that we retain unknown fields after a load/save cycle.
     """
     create(
-        'test.ics',
-        'UID:AVERYUNIQUEID\n'
+        'test.ics', 'UID:AVERYUNIQUEID\n'
         'SUMMARY:RAWR\n'
         'X-RAWR-TYPE:Reptar\n'
     )
@@ -209,14 +194,20 @@ def test_is_completed():
     assert todo.status == 'COMPLETED'
 
 
-@pytest.mark.parametrize('until', [
-    '20990315T020000Z',  # TZ-aware UNTIL
-    '20990315T020000',  # TZ-naive UNTIL
-])
-@pytest.mark.parametrize('tz', [
-    pytz.UTC,  # TZ-aware todos
-    None,  # TZ-naive todos
-])
+@pytest.mark.parametrize(
+    'until',
+    [
+        '20990315T020000Z',  # TZ-aware UNTIL
+        '20990315T020000',  # TZ-naive UNTIL
+    ]
+)
+@pytest.mark.parametrize(
+    'tz',
+    [
+        pytz.UTC,  # TZ-aware todos
+        None,  # TZ-naive todos
+    ]
+)
 @pytest.mark.parametrize('due', [
     True,
     False,
@@ -332,11 +323,7 @@ def test_todos_startable(tmpdir, runner, todo_factory, todos):
 
 
 def test_filename_uid_colision(create, default_database, runner, todos):
-    create(
-        'ABC.ics',
-        'SUMMARY:My UID is not ABC\n'
-        'UID:NOTABC\n'
-    )
+    create('ABC.ics', 'SUMMARY:My UID is not ABC\n' 'UID:NOTABC\n')
     len(list(todos())) == 1
 
     todo = Todo(new=False)
@@ -356,8 +343,7 @@ def test_hide_cancelled(todos, todo_factory):
 
 def test_illegal_start_suppression(create, default_database, todos):
     create(
-        'test.ics',
-        'SUMMARY:Start doing stuff\n'
+        'test.ics', 'SUMMARY:Start doing stuff\n'
         'DUE;VALUE=DATE-TIME;TZID=CET:20170331T120000\n'
         'DTSTART;VALUE=DATE-TIME;TZID=CET:20170331T140000\n'
     )
@@ -367,10 +353,7 @@ def test_illegal_start_suppression(create, default_database, todos):
 
 
 def test_default_status(create, todos):
-    create(
-        'test.ics',
-        'SUMMARY:Finish all these status tests\n'
-    )
+    create('test.ics', 'SUMMARY:Finish all these status tests\n')
     todo = next(todos())
     assert todo.status == 'NEEDS-ACTION'
 
@@ -399,7 +382,8 @@ def test_duplicate_list(tmpdir):
 
     with pytest.raises(AlreadyExists):
         Database(
-            [tmpdir.join('personal1'), tmpdir.join('personal2')],
+            [tmpdir.join('personal1'),
+             tmpdir.join('personal2')],
             tmpdir.join('cache.sqlite3'),
         )
 

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -9,8 +9,7 @@ from todoman.formatters import PorcelainFormatter
 
 def test_list_all(tmpdir, runner, create):
     create(
-        'test.ics',
-        'SUMMARY:Do stuff\n'
+        'test.ics', 'SUMMARY:Do stuff\n'
         'STATUS:COMPLETED\n'
         'DUE;VALUE=DATE-TIME;TZID=CET:20160102T000000\n'
         'PERCENT-COMPLETE:26\n'
@@ -30,14 +29,14 @@ def test_list_all(tmpdir, runner, create):
     }]
 
     assert not result.exception
-    assert result.output.strip() == json.dumps(expected, indent=4,
-                                               sort_keys=True)
+    assert result.output.strip() == json.dumps(
+        expected, indent=4, sort_keys=True
+    )
 
 
 def test_list_nodue(tmpdir, runner, create):
     create(
-        'test.ics',
-        'SUMMARY:Do stuff\n'
+        'test.ics', 'SUMMARY:Do stuff\n'
         'PERCENT-COMPLETE:12\n'
         'PRIORITY:4\n'
     )
@@ -55,76 +54,57 @@ def test_list_nodue(tmpdir, runner, create):
     }]
 
     assert not result.exception
-    assert result.output.strip() == json.dumps(expected, indent=4,
-                                               sort_keys=True)
+    assert result.output.strip() == json.dumps(
+        expected, indent=4, sort_keys=True
+    )
 
 
 def test_list_priority(tmpdir, runner, create):
-    result = runner.invoke(cli, ['--porcelain', 'list'],
-                           catch_exceptions=False)
+    result = runner.invoke(
+        cli, ['--porcelain', 'list'], catch_exceptions=False
+    )
     assert not result.exception
     assert result.output.strip() == '[]'
-    create(
-        'one.ics',
-        'SUMMARY:haha\n'
-        'PRIORITY:4\n'
-    )
-    create(
-        'two.ics',
-        'SUMMARY:hoho\n'
-        'PRIORITY:9\n'
-    )
-    create(
-        'three.ics',
-        'SUMMARY:hehe\n'
-        'PRIORITY:5\n'
-    )
-    create(
-        'four.ics',
-        'SUMMARY:huhu\n'
-    )
+    create('one.ics', 'SUMMARY:haha\n' 'PRIORITY:4\n')
+    create('two.ics', 'SUMMARY:hoho\n' 'PRIORITY:9\n')
+    create('three.ics', 'SUMMARY:hehe\n' 'PRIORITY:5\n')
+    create('four.ics', 'SUMMARY:huhu\n')
 
-    result_high = runner.invoke(cli, ['--porcelain', 'list',
-                                '--priority=4'])
+    result_high = runner.invoke(cli, ['--porcelain', 'list', '--priority=4'])
     assert not result_high.exception
     assert 'haha' in result_high.output
     assert 'hoho' not in result_high.output
     assert 'huhu' not in result_high.output
     assert 'hehe' not in result_high.output
 
-    result_medium = runner.invoke(cli, ['--porcelain', 'list',
-                                  '--priority=5'])
+    result_medium = runner.invoke(cli, ['--porcelain', 'list', '--priority=5'])
     assert not result_medium.exception
     assert 'haha' in result_medium.output
     assert 'hehe' in result_medium.output
     assert 'hoho' not in result_medium.output
     assert 'huhu' not in result_medium.output
 
-    result_low = runner.invoke(cli, ['--porcelain', 'list',
-                               '--priority=9'])
+    result_low = runner.invoke(cli, ['--porcelain', 'list', '--priority=9'])
     assert not result_low.exception
     assert 'haha' in result_low.output
     assert 'hehe' in result_low.output
     assert 'hoho' in result_low.output
     assert 'huhu' not in result_low.output
 
-    result_none = runner.invoke(cli, ['--porcelain', 'list',
-                                '--priority=0'])
+    result_none = runner.invoke(cli, ['--porcelain', 'list', '--priority=0'])
     assert not result_none.exception
     assert 'haha' in result_none.output
     assert 'hehe' in result_none.output
     assert 'hoho' in result_none.output
     assert 'huhu' in result_none.output
 
-    result_error = runner.invoke(cli, ['--porcelain', 'list',
-                                 '--priority=18'])
+    result_error = runner.invoke(cli, ['--porcelain', 'list', '--priority=18'])
     assert result_error.exception
 
 
 def test_show(tmpdir, runner, create):
     create(
-        'test.ics',
-        'SUMMARY:harhar\n'
+        'test.ics', 'SUMMARY:harhar\n'
         'DESCRIPTION:Lots of text. Yum!\n'
         'PRIORITY:5\n'
     )
@@ -142,8 +122,9 @@ def test_show(tmpdir, runner, create):
     }
 
     assert not result.exception
-    assert result.output.strip() == json.dumps(expected, indent=4,
-                                               sort_keys=True)
+    assert result.output.strip() == json.dumps(
+        expected, indent=4, sort_keys=True
+    )
 
 
 def test_simple_action(todo_factory):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -9,8 +9,9 @@ from urwid import ExitMainLoop
 from todoman.interactive import TodoEditor
 
 
-def test_todo_editor_priority(default_database, todo_factory,
-                              default_formatter):
+def test_todo_editor_priority(
+    default_database, todo_factory, default_formatter
+):
     todo = todo_factory(priority=1)
     lists = list(default_database.lists())
 
@@ -24,8 +25,9 @@ def test_todo_editor_priority(default_database, todo_factory,
     assert todo.priority is 0
 
 
-def test_todo_editor_list(default_database, todo_factory, default_formatter,
-                          tmpdir):
+def test_todo_editor_list(
+    default_database, todo_factory, default_formatter, tmpdir
+):
     tmpdir.mkdir('another_list')
 
     default_database.paths = [
@@ -38,14 +40,12 @@ def test_todo_editor_list(default_database, todo_factory, default_formatter,
     lists = list(default_database.lists())
 
     editor = TodoEditor(todo, lists, default_formatter)
-    default_list = next(filter(
-        lambda x: x.label == 'default',
-        editor.list_selector
-    ))
-    another_list = next(filter(
-        lambda x: x.label == 'another_list',
-        editor.list_selector
-    ))
+    default_list = next(
+        filter(lambda x: x.label == 'default', editor.list_selector)
+    )
+    another_list = next(
+        filter(lambda x: x.label == 'another_list', editor.list_selector)
+    )
 
     assert editor.current_list == todo.list
     assert default_list.label == todo.list.name
@@ -57,8 +57,9 @@ def test_todo_editor_list(default_database, todo_factory, default_formatter,
     assert another_list.label == todo.list.name
 
 
-def test_todo_editor_summary(default_database, todo_factory,
-                             default_formatter):
+def test_todo_editor_summary(
+    default_database, todo_factory, default_formatter
+):
     todo = todo_factory()
     lists = list(default_database.lists())
 
@@ -125,7 +126,7 @@ def test_show_save_errors(default_database, default_formatter, todo_factory):
     editor._due.set_edit_text('not a date')
     editor._keypress('ctrl s')
 
-    assert(
+    assert (
         editor.left_column.body.contents[2].get_text()[0] ==
         'Time description not recognized: not a date'
     )
@@ -152,8 +153,7 @@ def test_ctrl_c_clears(default_formatter, todo_factory):
     # Simulate that ctrl+c gets pressed, since we can't *really* do that
     # trivially inside unit tests.
     with mock.patch(
-        'urwid.main_loop.MainLoop.run',
-        side_effect=KeyboardInterrupt
+        'urwid.main_loop.MainLoop.run', side_effect=KeyboardInterrupt
     ), mock.patch(
         'urwid.main_loop.MainLoop.stop',
     ) as mocked_stop:

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -32,6 +32,7 @@ def catch_errors(f):
     def wrapper(*a, **kw):
         with handle_error():
             return f(*a, **kw)
+
     return wrapper
 
 
@@ -50,8 +51,7 @@ def _validate_list_param(ctx, param=None, name=None):
             name = ctx.config['main']['default_list']
         else:
             raise click.BadParameter(
-                'You must set "default_list" or use -l.'
-                .format(name)
+                'You must set "default_list" or use -l.'.format(name)
             )
     for l in ctx.db.lists():
         if l.name == name:
@@ -59,8 +59,7 @@ def _validate_list_param(ctx, param=None, name=None):
     else:
         list_names = [l.name for l in ctx.db.lists()]
         raise click.BadParameter(
-            "{}. Available lists are: {}"
-            .format(name, ', '.join(list_names))
+            "{}. Available lists are: {}".format(name, ', '.join(list_names))
         )
 
 
@@ -144,22 +143,39 @@ def validate_status(ctx=None, param=None, val=None):
 
 def _todo_property_options(command):
     click.option(
-        '--priority', default='', callback=_validate_priority_param,
-        help=('The priority for this todo'))(command)
-    click.option('--location', help=('The location where '
-                 'this todo takes place.'))(command)
+        '--priority',
+        default='',
+        callback=_validate_priority_param,
+        help=('The priority for this todo')
+    )(command)
     click.option(
-        '--due', '-d', default='', callback=_validate_date_param,
-        help=('The due date of the task, in the format specified in the '
-              'configuration file.'))(command)
+        '--location', help=('The location where '
+                            'this todo takes place.')
+    )(command)
     click.option(
-        '--start', '-s', default='', callback=_validate_date_param,
-        help='When the task starts.')(command)
+        '--due',
+        '-d',
+        default='',
+        callback=_validate_date_param,
+        help=(
+            'The due date of the task, in the format specified in the '
+            'configuration file.'
+        )
+    )(command)
+    click.option(
+        '--start',
+        '-s',
+        default='',
+        callback=_validate_date_param,
+        help='When the task starts.'
+    )(command)
 
     @functools.wraps(command)
     def command_wrap(*a, **kw):
-        kw['todo_properties'] = {key: kw.pop(key) for key in
-                                 ('due', 'start', 'location', 'priority')}
+        kw['todo_properties'] = {
+            key: kw.pop(key)
+            for key in ('due', 'start', 'location', 'priority')
+        }
         return command(*a, **kw)
 
     return command_wrap
@@ -190,24 +206,42 @@ class AppContext:
 
 pass_ctx = click.make_pass_decorator(AppContext)
 
-
 _interactive_option = click.option(
-    '--interactive', '-i', is_flag=True, default=None,
-    help='Go into interactive mode before saving the task.')
+    '--interactive',
+    '-i',
+    is_flag=True,
+    default=None,
+    help='Go into interactive mode before saving the task.'
+)
 
 
 @click.group(invoke_without_command=True)
 @click_log.simple_verbosity_option()
-@click.option('--colour', '--color', default=None,
-              type=click.Choice(['always', 'auto', 'never']),
-              help=('By default todoman will disable colored output if stdout '
-                    'is not a TTY (value `auto`). Set to `never` to disable '
-                    'colored output entirely, or `always` to enable it '
-                    'regardless.'))
-@click.option('--porcelain', is_flag=True, help='Use a JSON format that will '
-              'remain stable regardless of configuration or version.')
-@click.option('--humanize', '-h', default=None, is_flag=True,
-              help='Format all dates and times in a human friendly way')
+@click.option(
+    '--colour',
+    '--color',
+    default=None,
+    type=click.Choice(['always', 'auto', 'never']),
+    help=(
+        'By default todoman will disable colored output if stdout '
+        'is not a TTY (value `auto`). Set to `never` to disable '
+        'colored output entirely, or `always` to enable it '
+        'regardless.'
+    )
+)
+@click.option(
+    '--porcelain',
+    is_flag=True,
+    help='Use a JSON format that will '
+    'remain stable regardless of configuration or version.'
+)
+@click.option(
+    '--humanize',
+    '-h',
+    default=None,
+    is_flag=True,
+    help='Format all dates and times in a human friendly way'
+)
 @click.pass_context
 @click.version_option(prog_name='todoman')
 @catch_errors
@@ -219,8 +253,10 @@ def cli(click_ctx, color, porcelain, humanize):
         raise click.ClickException(e.args[0])
 
     if porcelain and humanize:
-        raise click.ClickException('--porcelain and --humanize cannot be used'
-                                   ' at the same time.')
+        raise click.ClickException(
+            '--porcelain and --humanize cannot be used'
+            ' at the same time.'
+        )
 
     if humanize is None:  # False means explicitly disabled
         humanize = ctx.config['main']['humanize']
@@ -276,8 +312,12 @@ except ImportError:
 
 @cli.command()
 @click.argument('summary', nargs=-1)
-@click.option('--list', '-l', callback=_validate_list_param,
-              help='The list to create the task in.')
+@click.option(
+    '--list',
+    '-l',
+    callback=_validate_list_param,
+    help='The list to create the task in.'
+)
 @_todo_property_options
 @_interactive_option
 @pass_ctx
@@ -435,8 +475,12 @@ def delete(ctx, ids, yes):
 
 @cli.command()
 @pass_ctx
-@click.option('--list', '-l', callback=_validate_list_param,
-              help='The list to copy the tasks to.')
+@click.option(
+    '--list',
+    '-l',
+    callback=_validate_list_param,
+    help='The list to copy the tasks to.'
+)
 @click.argument('ids', nargs=-1, required=True, type=click.IntRange(0))
 @catch_errors
 def copy(ctx, list, ids):
@@ -452,8 +496,12 @@ def copy(ctx, list, ids):
 
 @cli.command()
 @pass_ctx
-@click.option('--list', '-l', callback=_validate_list_param,
-              help='The list to move the tasks to.')
+@click.option(
+    '--list',
+    '-l',
+    callback=_validate_list_param,
+    help='The list to move the tasks to.'
+)
 @click.argument('ids', nargs=-1, required=True, type=click.IntRange(0))
 @catch_errors
 def move(ctx, list, ids):
@@ -471,27 +519,57 @@ def move(ctx, list, ids):
 @click.option('--location', help='Only show tasks with location containg TEXT')
 @click.option('--category', help='Only show tasks with category containg TEXT')
 @click.option('--grep', help='Only show tasks with message containg TEXT')
-@click.option('--sort', help='Sort tasks using these fields',
-              callback=_sort_callback)
-@click.option('--reverse/--no-reverse', default=True,
-              help='Sort tasks in reverse order (see --sort). '
-              'Defaults to true.')
-@click.option('--due', default=None, help='Only show tasks due in INTEGER '
-              'hours', type=int)
-@click.option('--priority', default=None, help='Only show tasks with'
-              ' priority at least as high as TEXT (low, medium or high).',
-              type=str, callback=_validate_priority_param)
-@click.option('--start', default=None, callback=_validate_start_date_param,
-              nargs=2, help='Only shows tasks before/after given DATE')
-@click.option('--startable', default=None, is_flag=True,
-              callback=_validate_startable_param, help='Show only todos which '
-              'should can be started today (i.e.: start time is not in the '
-              'future).')
-@click.option('--status', '-s', default=['NEEDS-ACTION', 'IN-PROCESS'],
-              callback=validate_status, help='Show only todos with the '
-              'provided comma-separated statuses. Valid statuses are '
-              '"NEEDS-ACTION", "CANCELLED", "COMPLETED", "IN-PROCESS" or "ANY"'
-              )
+@click.option(
+    '--sort',
+    help='Sort tasks using these fields',
+    callback=_sort_callback,
+)
+@click.option(
+    '--reverse/--no-reverse',
+    default=True,
+    help='Sort tasks in reverse order (see --sort). '
+    'Defaults to true.'
+)
+@click.option(
+    '--due',
+    default=None,
+    help='Only show tasks due in INTEGER '
+    'hours',
+    type=int
+)
+@click.option(
+    '--priority',
+    default=None,
+    help='Only show tasks with'
+    ' priority at least as high as TEXT (low, medium or high).',
+    type=str,
+    callback=_validate_priority_param
+)
+@click.option(
+    '--start',
+    default=None,
+    callback=_validate_start_date_param,
+    nargs=2,
+    help='Only shows tasks before/after given DATE'
+)
+@click.option(
+    '--startable',
+    default=None,
+    is_flag=True,
+    callback=_validate_startable_param,
+    help='Show only todos which '
+    'should can be started today (i.e.: start time is not in the '
+    'future).'
+)
+@click.option(
+    '--status',
+    '-s',
+    default=['NEEDS-ACTION', 'IN-PROCESS'],
+    callback=validate_status,
+    help='Show only todos with the '
+    'provided comma-separated statuses. Valid statuses are '
+    '"NEEDS-ACTION", "CANCELLED", "COMPLETED", "IN-PROCESS" or "ANY"'
+)
 @catch_errors
 def list(ctx, **kwargs):
     """

--- a/todoman/configuration.py
+++ b/todoman/configuration.py
@@ -63,9 +63,7 @@ def find_config():
         if exists(path):
             return path
 
-    raise ConfigurationException(
-        "No configuration file found.\n\n"
-    )
+    raise ConfigurationException("No configuration file found.\n\n")
 
 
 def load_config():
@@ -83,10 +81,10 @@ def load_config():
 
     for section, key, error in flatten_errors(config, validation):
         if not error:
-            raise ConfigurationException(
-                ('{} is missing from the {} section of the configuration ' +
-                 'file').format(key, section)
-            )
+            raise ConfigurationException((
+                '{} is missing from the {} section of the configuration ' +
+                'file'
+            ).format(key, section))
         if isinstance(error, VdtValueError):
             raise ConfigurationException(
                 'Bad {} setting, {}'.format(key, error.args[0])

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -28,15 +28,20 @@ def rgb_to_ansi(colour):
 
 
 class DefaultFormatter:
-
-    def __init__(self, date_format='%Y-%m-%d', time_format='%H:%M',
-                 dt_separator=' ', tz_override=None):
+    def __init__(
+        self,
+        date_format='%Y-%m-%d',
+        time_format='%H:%M',
+        dt_separator=' ',
+        tz_override=None
+    ):
         self.date_format = date_format
         self.time_format = time_format
         self.dt_separator = dt_separator
-        self.datetime_format = dt_separator.join(filter(bool, (
-            date_format, time_format
-        )))
+        self.datetime_format = dt_separator.join(
+            filter(bool,
+                   (date_format, time_format))
+        )
 
         self.tz = tz_override or tzlocal()
         self.now = datetime.datetime.now().replace(tzinfo=self.tz)
@@ -128,8 +133,10 @@ class DefaultFormatter:
         elif priority == 'none':
             return 0
         else:
-            raise ValueError('Priority has to be one of low, medium,'
-                             ' high or none')
+            raise ValueError(
+                'Priority has to be one of low, medium,'
+                ' high or none'
+            )
 
     def format_priority(self, priority):
         if not priority:
@@ -179,18 +186,16 @@ class DefaultFormatter:
 
         rv, pd_ctx = self._parsedatetime_calendar.parse(dt)
         if not pd_ctx.hasDateOrTime:
-            raise ValueError('Time description not recognized: {}' .format(dt))
+            raise ValueError('Time description not recognized: {}'.format(dt))
         return datetime.datetime.fromtimestamp(mktime(rv))
 
     def format_database(self, database):
         return '{}@{}'.format(
-            rgb_to_ansi(database.colour) or '',
-            click.style(database.name)
+            rgb_to_ansi(database.colour) or '', click.style(database.name)
         )
 
 
 class HumanizedFormatter(DefaultFormatter):
-
     def format_datetime(self, dt):
         if not dt:
             return ''
@@ -203,7 +208,6 @@ class HumanizedFormatter(DefaultFormatter):
 
 
 class PorcelainFormatter(DefaultFormatter):
-
     def _todo_as_dict(self, todo):
         return dict(
             completed=todo.is_completed,

--- a/todoman/interactive.py
+++ b/todoman/interactive.py
@@ -2,9 +2,7 @@ import urwid
 
 from todoman import widgets
 
-_palette = [
-    ('error', 'light red', '')
-]
+_palette = [('error', 'light red', '')]
 
 
 class TodoEditor:
@@ -32,14 +30,15 @@ class TodoEditor:
         buttons = urwid.Columns([(8, save_btn), cancel_text], dividechars=2)
 
         pile_items = []
-        for label, field in [("Summary", self._summary),
-                             ("Description", self._description),
-                             ("Location", self._location),
-                             ("Start", self._dtstart),
-                             ("Due", self._due),
-                             ("Completed", self._completed),
-                             ("Priority", self._priority),
-                             ]:
+        for label, field in [
+            ("Summary", self._summary),
+            ("Description", self._description),
+            ("Location", self._location),
+            ("Start", self._dtstart),
+            ("Due", self._due),
+            ("Completed", self._completed),
+            ("Priority", self._priority),
+        ]:
             label = urwid.Text(label + ":", align='right')
             column = urwid.Columns([(13, label), field], dividechars=1)
             pile_items.append(('pack', column))
@@ -47,15 +46,18 @@ class TodoEditor:
         grid = urwid.Pile(pile_items)
         spacer = urwid.Divider()
 
-        self.left_column = urwid.ListBox(urwid.SimpleListWalker([
-            grid,
-            spacer,
-            self._status,
-            buttons,
-        ]))
-        right_column = urwid.ListBox(urwid.SimpleListWalker(
-            [urwid.Text('List:\n')] + self.list_selector
-        ))
+        self.left_column = urwid.ListBox(
+            urwid.SimpleListWalker([
+                grid,
+                spacer,
+                self._status,
+                buttons,
+            ])
+        )
+        right_column = urwid.ListBox(
+            urwid.SimpleListWalker([urwid.Text('List:\n')] + self.list_selector
+                                   )
+        )
 
         self._ui = urwid.Columns([self.left_column, right_column])
 
@@ -81,10 +83,7 @@ class TodoEditor:
             parent=self,
             edit_text=self.formatter.format_datetime(self.todo.start),
         )
-        self._completed = urwid.CheckBox(
-            "",
-            state=self.todo.is_completed
-        )
+        self._completed = urwid.CheckBox("", state=self.todo.is_completed)
         self._priority = widgets.PrioritySelector(
             parent=self,
             priority=self.todo.priority,
@@ -110,13 +109,13 @@ class TodoEditor:
             ' Ctrl-C: Cancel\n'
             ' Ctrl-S: Save (only works if not a shell shortcut already)\n'
             '\n'
-            'In Textfields:\n'
-            + '\n'.join(' {}: {}'.format(k, v) for k, v
-                        in widgets.ExtendedEdit.HELP) +
-            '\n\n'
-            'In Priority Selector:\n'
-            + '\n'.join(' {}: {}'.format(k, v) for k, v
-                        in widgets.PrioritySelector.HELP)
+            'In Textfields:\n' + '\n'.join(
+                ' {}: {}'.format(k, v) for k, v in widgets.ExtendedEdit.HELP
+            ) + '\n\n'
+            'In Priority Selector:\n' + '\n'.join(
+                ' {}: {}'.format(k, v)
+                for k, v in widgets.PrioritySelector.HELP
+            )
         )
 
     def _change_current_list(self, radio_button, new_state, new_list):

--- a/todoman/widgets.py
+++ b/todoman/widgets.py
@@ -153,9 +153,9 @@ class PrioritySelector(urwid.Button):
     def _update_label(self, delta=0):
         for i, r in enumerate(PrioritySelector.RANGES):
             if self._priority in r:
-                self._priority = PrioritySelector.RANGES[
-                    (i + delta) % len(PrioritySelector.RANGES)
-                ][0]
+                self._priority = PrioritySelector.RANGES[(
+                    i + delta
+                ) % len(PrioritySelector.RANGES)][0]
                 self._set_label()
                 return
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,13 @@ deps =
   flake8-import-order
 commands = flake8
 
+[testenv:yapf]
+basepython = python3
+skip_install = True
+deps =
+  yapf
+commands = yapf --recursive --diff -p todoman tests docs setup.py
+
 [testenv:docs]
 basepython = python3
 whitelist_externals =


### PR DESCRIPTION
[yapf](https://github.com/google/yapf) is a code auto-formatting tool. I've configured it to strictly follow PEP-8, meaning it's another pep-8 checker, but the present configuration also allows quickly reformatting non-compliant code.

I'm generally happy with the changes done (it seems to introduce consistency, and clean up thing I generally didn't like).

I'm just hesitant because of [this bug](https://github.com/google/yapf/issues/462) which does affect the  codebase, and I'd also prefer to see [this](https://github.com/google/yapf/issues/461) implemented (though I guess that's not as critical).

Some assertions also [look kinda odd](https://github.com/pimutils/todoman/compare/master...yapf#diff-5d99b6fbb067a47380e72c50ef6357d1R236), though that *does* seem to be the _"proper"_ style.

My final hesitation is the size of this PR, since it kinda degrades the usefulness of things like `git blame` to find out why we introduced certain changes (though it's possible that the codebase is small and compact enough that this isn't really an issue).