### PR TITLE
Drop Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 
 python:
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ v3.3.0
 ------
 
 * New runtime dependency: ``click-log``.
+* Drop support for Python 3.3, which has reached its end of life cycle.
 
 v3.2.4
 ------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -64,7 +64,7 @@ lines to your ``~/.zshrc``::
 Requirements
 ------------
 
-Todoman requires python 3.3 or later. Installation of required libraries can be
+Todoman requires python 3.4 or later. Installation of required libraries can be
 done via pip, or your OS's package manager.
 
 Todoman will not work with python 2. However, keep in mind that python 2 and

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python 3.3 has reached its end of life, so support for it is being permanently dropped.