### PR TITLE
Allow raw edition of icalendar files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ v3.3.0
 
 * New runtime dependency: ``click-log``.
 * Drop support for Python 3.3, which has reached its end of life cycle.
+* Add `--raw` flag to `edit`. This allows editing the raw icalendar file, but
+  **only use this if you really know what you're doing**. There's a big risk of
+  data loss, and this is considered a developer / expert feature!
 
 v3.2.4
 ------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import datetime
 import sys
-from os.path import isdir
+from os.path import exists, isdir
 from unittest import mock
 from unittest.mock import patch
 
@@ -857,3 +857,19 @@ def test_duplicate_list(tmpdir, runner):
     assert result.exit_code == exceptions.AlreadyExists.EXIT_CODE
     assert result.output.strip() == \
         'More than one list has the same identity: personal.'
+
+
+def test_edit_raw(todo_factory, runner):
+    todo = todo_factory()
+    assert exists(todo.path)
+
+    with patch('click.edit', spec=True) as mocked_edit:
+        result = runner.invoke(
+            cli, ['edit', '--raw', '1'], catch_exceptions=False
+        )
+
+    assert mocked_edit.call_count == 1
+    assert mocked_edit.call_args == mock.call(filename=todo.path)
+
+    assert not result.exception
+    assert not result.output

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -352,15 +352,26 @@ def new(ctx, summary, list, todo_properties, interactive):
 
 @cli.command()
 @pass_ctx
+@click.option(
+    '--raw',
+    is_flag=True,
+    help=(
+        'Open the raw file for editing in $EDITOR.\n'
+        "Only use this if you REALLY know what you're doing!"
+    )
+)
 @_todo_property_options
 @_interactive_option
 @with_id_arg
 @catch_errors
-def edit(ctx, id, todo_properties, interactive):
+def edit(ctx, id, todo_properties, interactive, raw):
     '''
     Edit the task with id ID.
     '''
     todo = ctx.db.todo(id)
+    if raw:
+        click.edit(filename=todo.path)
+        return
     old_list = todo.list
 
     changes = False


### PR DESCRIPTION
I expected this to be much harder and take much longer, but looks like `click` has done all the heavy work for us.

Closes #285