### PR TITLE
Case-insensitive list name matching

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Authors are listed in alphabetical order.
 * José Ribeiro <hello@jlbribeiro.com>
 * Mansimar Kaur <mansimarkaur.mks@gmail.com>
 * Markus Unterwaditzer <markus@unterwaditzer.net>
+* Pascal Wichmann <wichmannpas@gmail.com>
 * Paweł Fertyk <pfertyk@openmailbox.org>
 * Rimsha Khan <rimshakhan.rk03@gmail.com>
 * Sakshi Saraswat <saraswatsakshi.121@gmail.com>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,26 @@ __all__ = [
     'pyicu_sensitive',
 ]
 
+import os
+from tempfile import TemporaryDirectory
+
 import pytest
+
+
+def is_fs_case_sensitive():
+    with TemporaryDirectory() as tmpdir:
+        os.mkdir(os.path.join(
+            tmpdir,
+            'casesensitivetest'
+        ))
+        try:
+            os.mkdir(os.path.join(
+                tmpdir,
+                'casesensitiveTEST'
+            ))
+            return True
+        except FileExistsError:
+            return False
 
 
 def is_pyicu_installed():
@@ -12,6 +31,12 @@ def is_pyicu_installed():
         return False
     else:
         return True
+
+
+fs_case_sensitive = pytest.mark.skipif(
+    not is_fs_case_sensitive(),
+    reason="This test cannot be run when the fs is not case sensitive.",
+)
 
 
 pyicu_sensitive = pytest.mark.skipif(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from dateutil.tz import tzlocal
 from freezegun import freeze_time
 from hypothesis import given
 
-from tests.helpers import pyicu_sensitive
+from tests.helpers import fs_case_sensitive, pyicu_sensitive
 from todoman.cli import cli, exceptions
 from todoman.model import Database, Todo
 
@@ -66,6 +66,7 @@ def test_percent(tmpdir, runner, create):
     assert '78%' in result.output
 
 
+@fs_case_sensitive
 @pytest.mark.parametrize(
     'list_name', [
         'default',
@@ -77,6 +78,7 @@ def test_list_case_insensitive(tmpdir, runner, create, list_name):
     assert not result.exception
 
 
+@fs_case_sensitive
 def test_list_case_insensitive_collision(tmpdir, runner, create):
     """
     Test that the case-insensitive list name matching is not used if
@@ -94,6 +96,7 @@ def test_list_case_insensitive_collision(tmpdir, runner, create):
     assert not result.exception
 
 
+@fs_case_sensitive
 def test_list_case_insensitive_other_collision(tmpdir, runner, create):
     """
     Test that the case-insensitive list name matching is used if a
@@ -109,15 +112,14 @@ def test_list_case_insensitive_other_collision(tmpdir, runner, create):
     assert not result.exception
 
 
-@pytest.mark.parametrize(
-    'list_name', [
-        'nonexistant',
-        'NONexistant',
-    ])
-def test_list_inexistant(tmpdir, runner, create, list_name):
-    result = runner.invoke(cli, ['list', list_name])
+def test_list_inexistant(tmpdir, runner, create):
+    result = runner.invoke(cli, ['list', 'nonexistant'])
     assert result.exception
-    assert 'Error: Invalid value for "lists": %s' % list_name in result.output
+    assert 'Error: Invalid value for "lists": nonexistant' in result.output
+
+    result = runner.invoke(cli, ['list', 'NONexistant'])
+    assert result.exception
+    assert 'Error: Invalid value for "lists": NONexistant' in result.output
 
 
 def test_show_existing(tmpdir, runner, create):

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -53,14 +53,27 @@ def _validate_list_param(ctx, param=None, name=None):
             raise click.BadParameter(
                 'You must set "default_list" or use -l.'.format(name)
             )
-    for l in ctx.db.lists():
-        if l.name == name:
-            return l
-    else:
-        list_names = [l.name for l in ctx.db.lists()]
-        raise click.BadParameter(
-            "{}. Available lists are: {}".format(name, ', '.join(list_names))
-        )
+    lists = {
+        list_.name: list_
+        for list_ in ctx.db.lists()
+    }
+    fuzzy_matches = [
+        list_
+        for list_ in lists.values()
+        if list_.name.lower() == name.lower()
+    ]
+
+    if len(fuzzy_matches) == 1:
+        return fuzzy_matches[0]
+
+    # case-insensitive matching collides or does not find a result,
+    # use exact matching
+    if name in lists:
+        return lists[name]
+    raise click.BadParameter(
+        "{}. Available lists are: {}".format(
+            name, ', '.join(list_.name for list_ in lists.values()))
+    )
 
 
 def _validate_date_param(ctx, param, val):


### PR DESCRIPTION
This patch brings case-insensitive list name matching for the list parameter if all list names are unique when converted to lowercase (i.e., if the case-insensitive matching would yield conflicts for any list, it is not used).