### PR TITLE
Use python3.6 for extra tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 cache: pip
 
 python:
+  - 3.6
   - 3.4
   - 3.5
-  - 3.6
   - 3.7-dev
   - pypy3.3-5.2-alpha1
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -137,7 +137,7 @@ def test_filtering_lists(tmpdir, runner, create):
 
 def test_due_aware(tmpdir, runner, create, now_for_tz):
     db = Database([tmpdir.join('default')], tmpdir.join('cache.sqlite'))
-    l = next(db.lists())
+    list_ = next(db.lists())
 
     for tz in ['CET', 'HST']:
         for i in [1, 23, 25, 48]:
@@ -145,7 +145,7 @@ def test_due_aware(tmpdir, runner, create, now_for_tz):
             todo.due = now_for_tz(tz) + timedelta(hours=i)
             todo.summary = '{}'.format(i)
 
-            todo.list = l
+            todo.list = list_
             db.save(todo)
 
     todos = list(db.todos(due=24))


### PR DESCRIPTION
"Extra tests" meaning things like flake8, docs, pyicu-compat and anything else that's not plain unit-tests.

This PR also includes fixes for recent breakage to `master` (introduced as a result of upstream changes).

* `flake8` fails due to a new check introduced. Code has been updated.
* `pyicu` is failing to install on Travis. I'm not sure why, but have reported this upstream: https://github.com/ovalhub/pyicu/issues/68