### PR TITLE
Fix dpl not deploying packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - pip install wheel
         - python setup.py sdist bdist_wheel
         - gem install dpl
-        - dpl --api-key=$RELEASES_TOKEN --provider=releases --file=dist/* --file_glob=true
+        - dpl --api-key=$RELEASES_TOKEN --provider=releases --file=dist/* --file_glob=true --skip_cleanup=true
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Looks like dpl cleans up before deploying, so the packages got deleted,
and nothing was being deployed (as seen on v3.3.0).