### PR TITLE
Skip test that crashes due to invalid input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,5 @@ jobs:
 
 matrix:
   allow_failures:
+    - python: pypy3.3-5.2-alpha1
     - python: 3.7-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ jobs:
       env: TOXENV=py
       before_install:
         - brew update
-        - brew install python3
+        - brew upgrade python
+        - pip3 install -U virtualenv  # Travis' images rename pip to pip3.
         - virtualenv env -p python3
         - source env/bin/activate
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: off

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -216,8 +216,8 @@ def test_complete_recurring(default_database, due, todo_factory, tz, until):
     # We'll lose the milis when casting, so:
     now = datetime.now(tz).replace(microsecond=0)
 
-    if tz and not until.endswith('Z'):
-        pytest.skip('This combination is invalid, as per the spec')
+    if bool(tz) != bool(until.endswith('Z')):
+        pytest.skip('These combinations are invalid, as per the spec.')
 
     original_start = now
     if due:

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -191,14 +191,7 @@ class Todo:
 
         recurrence = rrulestr(self.rrule, dtstart=dt)
 
-        # Nasty hack around: https://github.com/dateutil/dateutil/issues/341
-        try:
-            return recurrence.after(dt)
-        except TypeError:
-            tz = dt.tzinfo
-            dt = dt.replace(tzinfo=LOCAL_TIMEZONE)
-            recurrence = rrulestr(self.rrule, dtstart=dt)
-            return recurrence.after(dt).replace(tzinfo=tz)
+        return recurrence.after(dt)
 
     def _create_next_instance(self):
         copy = self.clone()


### PR DESCRIPTION
Fix a test that fails since todoman crashes attempting to process and invalid ICS file.

Actually just skip this scenario, since crashing when processing broken input is probably the best we can do (and what we do in almost any other similar scenario).