### PR TITLE
Add "todo edit --description" for comfy editing in external editor

### DIFF
--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -383,11 +383,18 @@ def new(ctx, summary, list, todo_properties, read_description, interactive):
         "Only use this if you REALLY know what you're doing!"
     )
 )
+@click.option(
+    '--description',
+    is_flag=True,
+    help=(
+        'Edit the description in an external editor.'
+    )
+)
 @_todo_property_options
 @_interactive_option
 @with_id_arg
 @catch_errors
-def edit(ctx, id, todo_properties, interactive, raw):
+def edit(ctx, id, todo_properties, interactive, raw, description):
     '''
     Edit the task with id ID.
     '''
@@ -402,6 +409,13 @@ def edit(ctx, id, todo_properties, interactive, raw):
         if value:
             changes = True
             setattr(todo, key, value)
+
+    if description:
+        old_description = todo.description
+        new_description = click.edit(todo.description)
+        if old_description != new_description:
+            todo.description = new_description
+            changes = True
 
     if interactive or (not changes and interactive is None):
         ui = TodoEditor(todo, ctx.db.lists(), ctx.ui_formatter)


### PR DESCRIPTION
My primary use case of todoman is comfortable editing of descriptions of tasks in a separate editor. The reason is that most data of a task is simple enough to be editable via low-bandwidth interfaces like android clients or thunderbird/lightning. But the description may contain a long text, so the use of a dedicated text editor is warranted.

Currently the same thing can be achieved by running `todo edit <taskid>`, pressing the arrow key down, then pressing `<C-O>`. With the option from this PR, all you need is to pass the `--description` option to the `edit` command to open the item directly in the editor.

Feel free to change the name of the option. Related issue: #292