### PR TITLE
Fix coloring with RGBA color strings

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -141,6 +141,6 @@ def test_formatting_parsing_consitency(default_formatter):
 def test_rgb_to_ansi():
     assert rgb_to_ansi(None) is None
     assert rgb_to_ansi('#8ab6d') is None
-    assert rgb_to_ansi('#8ab6d2f') is None
+    assert rgb_to_ansi('#8ab6d2f') == '\x1b[38;2;138;182;210m'
     assert rgb_to_ansi('red') is None
     assert rgb_to_ansi('#8ab6d2') == '\x1b[38;2;138;182;210m'

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -17,7 +17,7 @@ def rgb_to_ansi(colour):
     if not colour or not colour.startswith('#'):
         return
 
-    r, g, b = colour[1:3], colour[3:5], colour[5:8]
+    r, g, b = colour[1:3], colour[3:5], colour[5:7]
 
     if not len(r) == len(g) == len(b) == 2:
         return


### PR DESCRIPTION
Simple mistake preventing #rrggbbaa strings to be interpreted correctly.