### PR TITLE
Fix crash due to changes in icalendar 4.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+v3.5.0
+------
+* Fix crashes due to API changes in icalendar 4.0.3.
+* Dropped compatibility for icalendar < 4.0.3.
+
 v3.4.1
 ------
 * Support Python 3.7.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'click-log>=0.2.1',
         'configobj',
         'humanize',
-        'icalendar',
+        'icalendar>=4.0.3',
         'parsedatetime',
         'python-dateutil',
         'pyxdg',

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -63,7 +63,10 @@ def test_vtodo_serialization(todo_factory):
     writer = VtodoWritter(todo)
     vtodo = writer.serialize()
 
-    assert str(vtodo.get('categories')) == 'tea,drinking,hot'
+    assert (
+        [str(c) for c in vtodo.get('categories').cats] ==
+        ['tea', 'drinking', 'hot']
+    )
     assert str(vtodo.get('description')) == description
     assert vtodo.get('priority') == 7
     assert vtodo.decoded('due') == datetime(3000, 3, 21, tzinfo=tzlocal())

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -284,7 +284,7 @@ class VtodoWritter:
         if name in Todo.DATETIME_FIELDS:
             return self.normalize_datetime(value)
         if name in Todo.LIST_FIELDS:
-            return ','.join(value)
+            return value
         if name in Todo.INT_FIELDS:
             return int(value)
         if name in Todo.STRING_FIELDS:
@@ -537,6 +537,13 @@ class Cache:
 
         return rrule.to_ical().decode()
 
+    def _serialize_categories(self, todo, field):
+        categories = todo.get(field, [])
+        if not categories:
+            return ''
+
+        return ','.join([str(category) for category in categories.cats])
+
     def add_vtodo(self, todo, file_path, id=None):
         """
         Adds a todo into the cache.
@@ -587,7 +594,7 @@ class Cache:
             todo.get('status', 'NEEDS-ACTION'),
             todo.get('description', None),
             todo.get('location', None),
-            todo.get('categories', None),
+            self._serialize_categories(todo, 'categories'),
             todo.get('sequence', 1),
             self._serialize_datetime(todo, 'last-modified'),
             self._serialize_rrule(todo, 'rrule'),


### PR DESCRIPTION
Basically, tests for master are failing due to an API change in icalendar.

This fixes that. I wonder if we need to introduce additional test around calendars, or just wait for #323.