### PR TITLE
Use a defined sourceTime when using parsedatetime

### DIFF
--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -192,7 +192,8 @@ class DefaultFormatter:
         except ValueError:
             pass
 
-        rv, pd_ctx = self._parsedatetime_calendar.parse(dt)
+        now = datetime.datetime.now(self.tz)
+        rv, pd_ctx = self._parsedatetime_calendar.parse(dt, now)
         if not pd_ctx.hasDateOrTime:
             raise ValueError('Time description not recognized: {}'.format(dt))
         return datetime.datetime.fromtimestamp(mktime(rv))


### PR DESCRIPTION
When using the parsedatetime functionalities freezegun is not used to
compute the source time. If the tests are run too close to midnight it
might result in the computation of 'tomorrow' being another day then
now() + 24h (because time.localtime() will be the next day) … thus
failing test_default_due2.

Setting sourceTime when calling parsedatime will ensure the same base is
used for all tests.