### PR TITLE
Run CI actions for PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,6 @@
 name: Checks
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   styles:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   tests:


### PR DESCRIPTION
Run CI for PRs. Right now, PRs only run if they belong to the main repository, but not forks.