### PR TITLE
Support list or string for default_command config

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,6 +10,7 @@ when copying code from elsewhere).
 
 Authors are listed in alphabetical order.
 
+* Alex David <git@alexd.me>
 * Anubha Agrawal <anubhakannu@gmail.com>
 * Ben Boeckel <mathstuf@gmail.com>
 * Ben Moran <github@benmoran.net>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -816,27 +816,24 @@ def test_status_filtering(runner, todo_factory):
     assert "two" in result.output
 
 
-def test_invoke_command(runner, tmpdir):
+def test_default_command_string(runner, tmpdir):
     path = tmpdir.join("config")
     path.write("default_command = flush\n", "a")
 
-    flush = mock.MagicMock()
-    with patch.dict(cli.commands, values=dict(flush=flush)):
-        result = runner.invoke(cli, catch_exceptions=False)
-
-    assert not result.exception
-    assert not result.output.strip()
-    assert flush.call_count == 1
+    result = runner.invoke(cli, catch_exceptions=False)
+    assert (
+        "Are you sure you want to delete all done tasks?" in result.output
+    )
 
 
-def test_invoke_invalid_command(runner, tmpdir):
+def test_default_command_list(runner, tmpdir):
     path = tmpdir.join("config")
-    path.write("default_command = DoTheRobot\n", "a")
+    path.write("default_command = show, 1234\n", "a")
 
     result = runner.invoke(cli, catch_exceptions=False)
-
-    assert result.exception
-    assert "Error: Invalid setting for [main][default_command]" in result.output
+    assert (
+        "No todo with id 1234." in result.output
+    )
 
 
 def test_show_priority(runner, todo_factory, todos):

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -309,16 +309,13 @@ def cli(click_ctx, colour, porcelain, humanize, config):
     locale.setlocale(locale.LC_TIME, "")
 
     if not click_ctx.invoked_subcommand:
-        invoke_command(
-            click_ctx, ctx.config["main"]["default_command"],
-        )
+        invoke_command(click_ctx, ctx.config["main"]["default_command"])
 
 
-def invoke_command(click_ctx, command):
-    name, *args = command.split(" ")
-    if name not in cli.commands:
-        raise click.ClickException("Invalid setting for [main][default_command]")
-    click_ctx.invoke(cli.commands[command], args)
+def invoke_command(click_ctx, argv):
+    if not isinstance(argv, type([])):
+        argv = [argv]
+    cli.invoke(cli.make_context("default_command", argv, click_ctx))
 
 
 try:  # pragma: no cover

--- a/todoman/confspec.ini
+++ b/todoman/confspec.ini
@@ -50,8 +50,8 @@ cache_path = cache_path(default='')
 # partially-complete) # are also included.
 startable = boolean(default=False)
 
-# When running ``todo`` with no commands, run this command.
-default_command = string(default='list')
+# When running ``todo`` with no arguments, use the following values.
+default_command = list(default='list')
 
 # The default priority of a task on creation.
 # Highest priority is 1, lowest priority is 10, and 0 means no priority at all.


### PR DESCRIPTION
Fixes #348 

`default_command` can now be either a string (as before):
```
default_command = flush
```

or a list which is passed directly to argv:
```
default_command = --color, never, list, --startable
```

Let me know if you want me to add any documentation around this, and if so, where