### PR TITLE
Update tests for click 7.1.0

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,8 +34,8 @@ def test_no_default_list(runner):
 
     assert result.exception
     assert (
-        'Error: Invalid value for "--list" / "-l": You must set '
-        '"default_list" or use -l.' in result.output
+        "Error: Invalid value for '--list' / '-l': You must set "
+        "`default_list` or use -l." in result.output
     )
 
 
@@ -116,14 +116,14 @@ def test_list_inexistant(tmpdir, runner, create):
     result = runner.invoke(cli, ['list', 'nonexistant'])
     assert result.exception
     assert (
-        'Error: Invalid value for "[LISTS]...": nonexistant'
+        "Error: Invalid value for '[LISTS]...': nonexistant"
         in result.output
     )
 
     result = runner.invoke(cli, ['list', 'NONexistant'])
     assert result.exception
     assert (
-        'Error: Invalid value for "[LISTS]...": NONexistant'
+        "Error: Invalid value for '[LISTS]...': NONexistant"
         in result.output
     )
 
@@ -401,7 +401,7 @@ def test_sort_invalid_fields(runner):
     result = runner.invoke(cli, ['list', '--sort', 'hats'])
 
     assert result.exception
-    assert 'Invalid value for "--sort": Unknown field "hats"' in result.output
+    assert "Invalid value for '--sort': Unknown field 'hats'" in result.output
 
 
 @pytest.mark.parametrize('hours', [72, -72])
@@ -597,7 +597,7 @@ def test_due_bad_date(runner):
 
     assert result.exception
     assert (
-        'Error: Invalid value for "--due" / "-d": Time description not '
+        "Error: Invalid value for '--due' / '-d': Time description not "
         'recognized: Not a date' == result.output.strip().splitlines()[-1]
     )
 
@@ -713,7 +713,7 @@ def test_bad_start_date(runner):
     result = runner.invoke(cli, ['list', '--start', 'before', 'not_a_date'])
     assert result.exception
     assert (
-        'Invalid value for "--start": Time description not recognized: '
+        "Invalid value for '--start': Time description not recognized: "
         'not_a_date' in result.output
     )
 

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -50,9 +50,7 @@ def _validate_list_param(ctx, param=None, name=None):
         if ctx.config['main']['default_list']:
             name = ctx.config['main']['default_list']
         else:
-            raise click.BadParameter(
-                'You must set "default_list" or use -l.'.format(name)
-            )
+            raise click.BadParameter("You must set `default_list` or use -l.")
     lists = {
         list_.name: list_
         for list_ in ctx.db.lists()
@@ -127,7 +125,7 @@ def _sort_callback(ctx, param, val):
             field = field[1:]
 
         if field not in Todo.ALL_SUPPORTED_FIELDS and field != 'id':
-            raise click.BadParameter('Unknown field "{}"'.format(field))
+            raise click.BadParameter("Unknown field '{}'".format(field))
 
     return fields
 


### PR DESCRIPTION
Click 7.1.0 changed the way errors are printed validation failures.

This PR updates tests so that they pass again, however, it's probably a good idea to rethink how these are designed a bit -- maybe it's possible to capture the exception that's raised and analyse that,
instead of the string?