### PR TITLE
Remove some leftover references to Python 3.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ v3.6.0
 * ``click-repl`` is now listed as an optional dependency. It is required for
   the ``todo repl`` command.
 * Add the ``default_priority`` config setting.
+* Drop support for Python 3.4.
 
 v3.5.0
 ------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -77,7 +77,7 @@ installations.
 Requirements
 ------------
 
-Todoman requires python 3.4 or later. Installation of required libraries can be
+Todoman requires python 3.5 or later. Installation of required libraries can be
 done via pip, or your OS's package manager.
 
 Todoman will not work with python 2. However, keep in mind that python 2 and

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py35, py36, flake8, docs
+envlist = py33, py35, py36, flake8, docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.4 was dropped some time ago, but some references were left behind.