### PR TITLE
pass arguments properly to invoke

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -828,6 +828,9 @@ def test_invoke_command(runner, tmpdir):
     path.write("default_command = flush\n", "a")
 
     flush = mock.MagicMock()
+    parser = mock.MagicMock()
+    flush.make_parser.return_value = parser
+    parser.parse_args.return_value = {}, [], []
     with patch.dict(cli.commands, values=dict(flush=flush)):
         result = runner.invoke(cli, catch_exceptions=False)
 

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -316,10 +316,14 @@ def cli(click_ctx, colour, porcelain, humanize, config):
 
 
 def invoke_command(click_ctx, command):
-    name, *args = command.split(" ")
+    name, *raw_args = command.split(" ")
     if name not in cli.commands:
         raise click.ClickException("Invalid setting for [main][default_command]")
-    click_ctx.invoke(cli.commands[name], args)
+    parser = cli.commands[name].make_parser(click_ctx)
+    opts, args, param_order = parser.parse_args(raw_args)
+    for param in param_order:
+        opts[param.name] = param.handle_parse_result(click_ctx, opts, args)[0]
+    click_ctx.invoke(cli.commands[name], *args, **opts)
 
 
 try:  # pragma: no cover


### PR DESCRIPTION
The arguments being passed to invoke weren't doing anything.

Now they are properly parsed, converted (sort as list, due as integer, ...) and passed to invoke.