### PR TITLE
pass arguments properly to invoke

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -822,6 +822,9 @@ def test_invoke_command(runner, tmpdir, config):
     config.write('default_command = "flush"\n', "a")
 
     flush = mock.MagicMock()
+    parser = mock.MagicMock()
+    flush.make_parser.return_value = parser
+    parser.parse_args.return_value = {}, [], []
     with patch.dict(cli.commands, values={"flush": flush}):
         result = runner.invoke(cli, catch_exceptions=False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import datetime
 import sys
 from os.path import exists
 from unittest import mock
+from unittest.mock import call
 from unittest.mock import patch
 
 import click
@@ -942,3 +943,28 @@ def test_invalid_default_priority(config, runner, create):
     result = runner.invoke(cli, ["new", "-l", "default", "aaa"])
     assert result.exception
     assert "Error: Invalid `default_priority` settings." in result.output
+
+
+def test_default_command_args(config, runner):
+    config.write(
+        'default_command = "list --sort=due --due 168 ' '--priority low --no-reverse"',
+        "a",
+    )
+
+    with patch("todoman.model.Database.todos", spec=True) as todos:
+        result = runner.invoke(cli)
+
+    assert not result.exception
+    assert todos.call_args == call(
+        sort=["due"],
+        due=168,
+        priority=9,
+        reverse=False,
+        lists=[],
+        location=None,
+        category=None,
+        grep=None,
+        start=None,
+        startable=None,
+        status="NEEDS-ACTION,IN-PROCESS",
+    )

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -309,10 +309,14 @@ def cli(click_ctx, colour, porcelain, humanize, config):
 
 
 def invoke_command(click_ctx, command):
-    name, *args = command.split(" ")
+    name, *raw_args = command.split(" ")
     if name not in cli.commands:
         raise click.ClickException("Invalid setting for [default_command]")
-    click_ctx.invoke(cli.commands[name], args)
+    parser = cli.commands[name].make_parser(click_ctx)
+    opts, args, param_order = parser.parse_args(raw_args)
+    for param in param_order:
+        opts[param.name] = param.handle_parse_result(click_ctx, opts, args)[0]
+    click_ctx.invoke(cli.commands[name], *args, **opts)
 
 
 try:  # pragma: no cover


### PR DESCRIPTION
The arguments being passed to invoke weren't doing anything.

Now they are properly parsed, converted (sort as list, due as integer, ...) and passed to invoke.

Example from my config file:
```
default_command = "list --sort=due --due 168 --priority low --no-reverse tasks"
```

The arguments to list would be ignored without these changes.