### PR TITLE
Tidy up CI publishing task

### DIFF
--- a/.builds/py39.yaml
+++ b/.builds/py39.yaml
@@ -33,8 +33,8 @@ tasks:
       cd todoman
       sudo pip install pre-commit
       pre-commit run --all
+      git describe --exact-match --tags || complete-build
   - publish: |
       cd todoman
       python setup.py sdist bdist_wheel
-      git describe --exact-match --tags || exit 0
       twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Todoman
 =======
 
-.. image:: https://action-badges.now.sh/pimutils/todoman
-  :target: https://github.com/pimutils/todoman/actions
+.. image:: https://builds.sr.ht/~whynothugo/todoman.svg
+  :target: https://builds.sr.ht/~whynothugo/todoman
   :alt: CI status
 
 .. image:: https://codecov.io/gh/pimutils/todoman/branch/main/graph/badge.svg


### PR DESCRIPTION
This'll mostly result in better output from CI, where the `publish` job is clearly marked as skipped.