### PR TITLE
Add option for printing the description in list

### DIFF
--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -607,6 +607,14 @@ def move(ctx, list, ids):
         '"NEEDS-ACTION", "CANCELLED", "COMPLETED", "IN-PROCESS" or "ANY"'
     ),
 )
+@click.option(
+    "--description/--no-description",
+    "-v",
+    default=False,
+    help=(
+        "Show description. Defaults to false."
+    ),
+)
 @catch_errors
 def list(ctx, *args, **kwargs):
     """
@@ -631,4 +639,4 @@ def list(ctx, *args, **kwargs):
     )
 
     todos = ctx.db.todos(**kwargs)
-    click.echo(ctx.formatter.compact_multiple(todos, hide_list))
+    click.echo(ctx.formatter.compact_multiple(todos, hide_list, kwargs["description"]))

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -62,7 +62,7 @@ class DefaultFormatter:
     def compact(self, todo: Todo) -> str:
         return self.compact_multiple([todo])
 
-    def compact_multiple(self, todos: Iterable[Todo], hide_list=False) -> str:
+    def compact_multiple(self, todos: Iterable[Todo], hide_list=False, description=False) -> str:
         table = []
         for todo in todos:
             completed = "X" if todo.is_completed else " "
@@ -100,6 +100,7 @@ class DefaultFormatter:
                     priority,
                     f"{due} {recurring}",
                     summary,
+                    todo.description if description else None,
                 ]
             )
 

--- a/todoman/model.py
+++ b/todoman/model.py
@@ -713,6 +713,7 @@ class Cache:
         start=None,
         startable=False,
         status="NEEDS-ACTION,IN-PROCESS",
+        description=False,
     ) -> Iterable[Todo]:
         """
         Returns filtered cached todos, in a specified order.


### PR DESCRIPTION
I'm opening a pull request about this, not to get my hack without tests and documentation merged, but perhaps to get tips on how to achieve what I want for my todoman workflow. This is pretty much the best I can do with python in an hour, I'm pretty unexperienced at not-so-strongly typed languages. Don't merge this as is :D 

Thanks for creating todoman, it's a great tool to organize my job. Thing is, I want to also see the descriptions of my items in lists to refresh my memory about my "subtasks"/checklists (which OpenTasks on Android supports). I'm thinking the easiest for me to actually implement this feature would be to write a custom wrapper for todoman's --porcelain which could then pretty-print in just the way(s) I want it to.