### PR TITLE
When we read in binary mode, write using it as well, fixes writing under Windows

### DIFF
--- a/todoman/model.py
+++ b/todoman/model.py
@@ -390,8 +390,8 @@ class VtodoWriter:
                 if component.get("uid", None) == self.todo.uid:
                     cal.subcomponents[index] = vtodo
 
-        with AtomicWriter(path, overwrite=True).open() as f:
-            f.write(cal.to_ical().decode("UTF-8"))
+        with AtomicWriter(path, "wb", overwrite=True).open() as f:
+            f.write(cal.to_ical())
 
     def _write_new(self, path):
         vtodo = self.serialize()
@@ -399,10 +399,10 @@ class VtodoWriter:
         c = icalendar.Calendar()
         c.add_component(vtodo)
 
-        with AtomicWriter(path).open() as f:
+        with AtomicWriter(path, "wb").open() as f:
             c.add("prodid", "io.barrera.todoman")
             c.add("version", "2.0")
-            f.write(c.to_ical().decode("UTF-8"))
+            f.write(c.to_ical())
 
         return vtodo
 


### PR DESCRIPTION
<!--

Items to keep in mind:

- When opening a PR tests will run, you'll be notified if any tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for your.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->
Under Windows, the distinction between binary or text mode actually exists, this PR allows to run the creation commands under Windows.