### PR TITLE
Use a fluid layout for TODOs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+v4.1.0
+------
+
+* The "table" layout has been dropped in favour of a simpler, fluid layout. As
+  such, ``tabulate`` is not longer a required dependency.
+
 v4.0.1
 ------
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         "parsedatetime",
         "python-dateutil",
         "pyxdg",
-        "tabulate",
         "urwid",
     ],
     long_description=open("README.rst").read(),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -401,12 +401,14 @@ def test_color_due_dates(tmpdir, runner, create, hours):
     assert not result.exception
     due_str = due.strftime("%Y-%m-%d")
     if hours == 72:
-        assert result.output == f"1  [ ]    {due_str}  aaa @default\x1b[0m\n"
-    else:
-        assert (
-            result.output
-            == f"1  [ ]    \x1b[31m{due_str}\x1b[0m  aaa @default\x1b[0m\n"
+        expected = (
+            f"[ ] 1 \x1b[35m\x1b[0m \x1b[37m{due_str}\x1b[0m aaa @default\x1b[0m\n"
         )
+    else:
+        expected = (
+            f"[ ] 1 \x1b[35m\x1b[0m \x1b[31m{due_str}\x1b[0m aaa @default\x1b[0m\n"
+        )
+    assert result.output == expected
 
 
 def test_color_flag(runner, todo_factory):
@@ -415,16 +417,16 @@ def test_color_flag(runner, todo_factory):
     result = runner.invoke(cli, ["--color", "always"], color=True)
     assert (
         result.output.strip()
-        == "1  [ ]    \x1b[31m2007-03-22\x1b[0m  YARR! @default\x1b[0m"
+        == "[ ] 1 \x1b[35m\x1b[0m \x1b[31m2007-03-22\x1b[0m YARR! @default\x1b[0m"
     )
     result = runner.invoke(cli, color=True)
     assert (
         result.output.strip()
-        == "1  [ ]    \x1b[31m2007-03-22\x1b[0m  YARR! @default\x1b[0m"
+        == "[ ] 1 \x1b[35m\x1b[0m \x1b[31m2007-03-22\x1b[0m YARR! @default\x1b[0m"
     )
 
     result = runner.invoke(cli, ["--color", "never"], color=True)
-    assert result.output.strip() == "1  [ ]    2007-03-22  YARR! @default"
+    assert result.output.strip() == "[ ] 1  2007-03-22 YARR! @default"
 
 
 def test_flush(tmpdir, runner, create, todo_factory, todos):
@@ -740,7 +742,7 @@ def test_cancel(runner, todo_factory, todos):
 def test_id_printed_for_new(runner):
     result = runner.invoke(cli, ["new", "-l", "default", "show me an id"])
     assert not result.exception
-    assert result.output.strip().startswith("1")
+    assert result.output.strip().startswith("[ ] 1")
 
 
 def test_repl(runner):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -91,15 +91,19 @@ def test_detailed_format(runner, todo_factory):
 
     # TODO:use formatter instead of runner?
     result = runner.invoke(cli, ["show", "1"])
-    expected = (
-        "1  [ ]      YARR! @default\n\n"
-        "Description  Test detailed formatting\n"
-        "             This includes multiline descriptions\n"
-        "             Blah!\n"
-        "Location     Over the hills, and far away"
-    )
+    expected = [
+        "[ ] 1  (no due date) YARR! @default",
+        "",
+        "Description:",
+        "Test detailed formatting",
+        "This includes multiline descriptions",
+        "Blah!",
+        "",
+        "Location: Over the hills, and far away",
+    ]
+
     assert not result.exception
-    assert result.output.strip() == expected
+    assert result.output.strip().splitlines() == expected
 
 
 def test_parse_time(default_formatter):
@@ -168,7 +172,7 @@ def test_format_multiple_with_list(default_formatter, todo_factory):
     assert todo.list
     assert (
         default_formatter.compact_multiple([todo])
-        == "1  [ ]      YARR! @default\x1b[0m"
+        == "[ ] 1 \x1b[35m\x1b[0m \x1b[37m(no due date)\x1b[0m YARR! @default\x1b[0m"
     )
 
 


### PR DESCRIPTION
Stop drawing a table as done previously, and use a fluid layout. This
reduces internal whitespace, which makes the ids for todos easier to
recognise in may scenarios.

Also makes the description and location blocks easier to copy-paste
verbatim without additional indentation.

Due to dropping the table rendering, this should slightly improve
performance, though that's not a main goal here.