### PR TITLE
Added "read from stdin" option to edit command

### DIFF
--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -381,6 +381,13 @@ def new(ctx, summary, list, todo_properties, read_description, interactive):
 @cli.command()
 @pass_ctx
 @click.option(
+    "--read-description",
+    "-r",
+    is_flag=True,
+    default=False,
+    help="Read task description from stdin.",
+)
+@click.option(
     "--raw",
     is_flag=True,
     help=(
@@ -392,7 +399,7 @@ def new(ctx, summary, list, todo_properties, read_description, interactive):
 @_interactive_option
 @with_id_arg
 @catch_errors
-def edit(ctx, id, todo_properties, interactive, raw):
+def edit(ctx, id, todo_properties, interactive, read_description, raw):
     """
     Edit the task with id ID.
     """
@@ -407,6 +414,10 @@ def edit(ctx, id, todo_properties, interactive, raw):
         if value is not None:
             changes = True
             setattr(todo, key, value)
+
+    if read_description:
+        changes = True
+        todo.description = "\n".join(sys.stdin)
 
     if interactive or (not changes and interactive is None):
         ui = TodoEditor(todo, ctx.db.lists(), ctx.ui_formatter)


### PR DESCRIPTION
Added `-r` (`--read-description`) flag to `edit` command.

This option is vital for my workflow: I use todoman inside a container to sync data between Calendars, Tasks, and also Kanboard. I need to sync back kanboard cards' URLs to tasks' descriptions.

<!--

Items to keep in mind:

- When opening a PR tests will run, you'll be notified if any tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for your.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->
