### PR TITLE
Configure setuptools_scm via pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+
+[tool.setuptools_scm]
+write_to = "todoman/version.py"
+version_scheme = "post-release"

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,6 @@ setup(
         "urwid",
     ],
     long_description=open("README.rst").read(),
-    use_scm_version={
-        "version_scheme": "post-release",
-        "write_to": "todoman/version.py",
-    },
     setup_requires=["setuptools_scm"],
     tests_require=open("requirements-dev.txt").readlines(),
     extras_require={


### PR DESCRIPTION
Configuring it via `setup.py` is deprecated. Use `python -m
setuptools_scm` to get the version of the current checkout.
