### PR TITLE
Switch to ruff for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,27 +8,10 @@ repos:
       - id: check-toml
       - id: check-added-large-files
       - id: debug-statements
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
   - repo: https://github.com/psf/black
-    rev: "22.10.0"
+    rev: "22.12.0"
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: "6.0.0" # pick a git hash / tag to point to
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-comprehensions
-          - flake8-bugbear
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
-    hooks:
-    -   id: pyupgrade
-        args: [--py38-plus]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.991"
     hooks:
@@ -39,3 +22,8 @@ repos:
           - types-freezegun
           - types-pytz
           - types-python-dateutil
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.224'
+    hooks:
+      - id: ruff
+        args: ["--force-exclude"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,29 @@
+[tool.ruff]
+exclude = [
+    ".tox",
+    "build",
+    ".eggs",
+]
+select = [
+    "E",
+    "F",
+    "W",
+    "B",
+    "I",
+    "UP",
+    # "N",
+    # "ANN",
+    # "A",
+    "C4",
+    # "PT",
+    # "SIM",
+    "TID",
+]
+target-version = "py38"
+
+[tool.ruff.isort]
+force-single-line = true
+
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
-flake8
-flake8-import-order
 freezegun
 hypothesis
 pytest
 pytest-cov
 pytest-runner
+ruff

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,21 +1,9 @@
-[flake8]
-exclude=.tox,build,.eggs
-extend-ignore =
-  # Black-incompatible colon spacing.
-  E203,
-  # Line jump before binary operator.
-  W503,
-max-line-length = 88
-
 [aliases]
 test=pytest
 
 [tool:pytest]
 testpaths = tests
 addopts = --cov=todoman --cov-report=term-missing --color=yes --verbose
-
-[isort]
-force_single_line=true
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 from setuptools import setup
 
+with open("README.rst") as r:
+    long_description = r.read()
+with open("requirements-dev.txt") as r:
+    tests_require = (r.readlines(),)
+with open("requirements-docs.txt") as r:
+    docs = r.readlines()
+
 setup(
     name="todoman",
     description="A simple icalendar-based todo manager.",
@@ -22,11 +29,11 @@ setup(
         "pyxdg",
         "urwid",
     ],
-    long_description=open("README.rst").read(),
+    long_description=long_description,
     setup_requires=["setuptools_scm"],
-    tests_require=open("requirements-dev.txt").readlines(),
+    tests_require=tests_require,
     extras_require={
-        "docs": open("requirements-docs.txt").readlines(),
+        "docs": docs,
         "repl": ["click-repl>=0.1.6"],
     },
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from todoman.formatters import DefaultFormatter
 from todoman.formatters import HumanizedFormatter
 
 
-@pytest.fixture
+@pytest.fixture()
 def default_database(tmpdir):
     return model.Database(
         [tmpdir.mkdir("default")],
@@ -24,7 +24,7 @@ def default_database(tmpdir):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def config(tmpdir, default_database):
     config_path = tmpdir.join("config.py")
     config_path.write(
@@ -36,7 +36,7 @@ def config(tmpdir, default_database):
     return config_path
 
 
-@pytest.fixture
+@pytest.fixture()
 def runner(config, sleep):
     class SleepyCliRunner(CliRunner):
         """
@@ -50,7 +50,7 @@ def runner(config, sleep):
     return SleepyCliRunner(env={"TODOMAN_CONFIG": str(config)})
 
 
-@pytest.fixture
+@pytest.fixture()
 def create(tmpdir):
     def inner(name, content, list_name="default"):
         path = tmpdir.ensure_dir(list_name).join(name)
@@ -62,7 +62,7 @@ def create(tmpdir):
     return inner
 
 
-@pytest.fixture
+@pytest.fixture()
 def now_for_tz():
     def inner(tz="CET"):
         """
@@ -77,7 +77,7 @@ def now_for_tz():
     return inner
 
 
-@pytest.fixture
+@pytest.fixture()
 def todo_factory(default_database):
     def inner(**attributes):
         todo = model.Todo(new=True)
@@ -94,13 +94,13 @@ def todo_factory(default_database):
     return inner
 
 
-@pytest.fixture
+@pytest.fixture()
 def default_formatter():
     formatter = DefaultFormatter(tz_override=pytz.timezone("CET"))
     return formatter
 
 
-@pytest.fixture
+@pytest.fixture()
 def humanized_formatter():
     formatter = HumanizedFormatter(tz_override=pytz.timezone("CET"))
     return formatter
@@ -148,7 +148,7 @@ def sleep(tmpdir_factory):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def todos(default_database, sleep):
     def inner(**filters):
         sleep()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,9 +29,8 @@ def test_xdg_nonexistant(runner):
 
 
 def test_xdg_existant(runner, tmpdir, config):
-    with tmpdir.mkdir("todoman").join("config.py").open("w") as f:
-        with config.open() as c:
-            f.write(c.read())
+    with tmpdir.mkdir("todoman").join("config.py").open("w") as f, config.open() as c:
+        f.write(c.read())
 
     with patch("xdg.BaseDirectory.xdg_config_dirs", [str(tmpdir)]):
         result = CliRunner().invoke(

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import glob
 import locale
@@ -332,13 +333,11 @@ def invoke_command(click_ctx, command):
     click_ctx.invoke(cli.commands[name], *args, **opts)
 
 
-try:  # pragma: no cover
+with contextlib.suppress(ImportError):
     import click_repl
 
     click_repl.register_repl(cli)
     click_repl.register_repl(cli, name="shell")
-except ImportError:
-    pass
 
 
 @cli.command()

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -79,7 +79,7 @@ def _validate_date_param(ctx, param, val):
     try:
         return ctx.formatter.parse_datetime(val)
     except ValueError as e:
-        raise click.BadParameter(e)
+        raise click.BadParameter(e) from None
 
 
 def _validate_categories_param(ctx, param, val):
@@ -92,7 +92,7 @@ def _validate_priority_param(ctx, param, val):
     try:
         return ctx.formatter.parse_priority(val)
     except ValueError as e:
-        raise click.BadParameter(e)
+        raise click.BadParameter(e) from None
 
 
 def _validate_start_date_param(ctx, param, val):
@@ -109,7 +109,7 @@ def _validate_start_date_param(ctx, param, val):
         dt = ctx.formatter.parse_datetime(val[1])
         return is_before, dt
     except ValueError as e:
-        raise click.BadParameter(e)
+        raise click.BadParameter(e) from None
 
 
 def _validate_startable_param(ctx, param, val):
@@ -279,7 +279,7 @@ def cli(click_ctx, colour, porcelain, humanize, config):
     try:
         ctx.config = load_config(config)
     except ConfigurationException as e:
-        raise click.ClickException(e.args[0])
+        raise click.ClickException(e.args[0]) from None
 
     if porcelain and humanize:
         raise click.ClickException(

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 from datetime import date
 from datetime import datetime
@@ -211,22 +212,16 @@ class DefaultFormatter:
 
     def _parse_datetime_naive(self, dt: str) -> date:
         """Parse dt and returns a naive datetime or a date"""
-        try:
+        with contextlib.suppress(ValueError):
             return datetime.strptime(dt, self.datetime_format)
-        except ValueError:
-            pass
 
-        try:
+        with contextlib.suppress(ValueError):
             return datetime.strptime(dt, self.date_format).date()
-        except ValueError:
-            pass
 
-        try:
+        with contextlib.suppress(ValueError):
             return datetime.combine(
                 self.now.date(), datetime.strptime(dt, self.time_format).time()
             )
-        except ValueError:
-            pass
 
         rv, pd_ctx = self._parsedatetime_calendar.parse(dt)
         if not pd_ctx.hasDateOrTime:

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -284,7 +284,7 @@ class PorcelainFormatter(DefaultFormatter):
             else:
                 raise ValueError("Priority has to be in the range 0-9")
         except ValueError as e:
-            raise click.BadParameter(str(e))
+            raise click.BadParameter(str(e)) from None
 
     def detailed(self, todo: Todo) -> str:
         return self.compact(todo)

--- a/todoman/widgets.py
+++ b/todoman/widgets.py
@@ -74,10 +74,7 @@ class ExtendedEdit(urwid.Edit):
         t = text[: self.edit_pos].rstrip()
 
         words = re.findall(r"[\w]+|[^\w\s]", t, re.UNICODE)
-        if t == "":
-            f_text = t
-        else:
-            f_text = t[: len(t) - len(words[-1])]
+        f_text = t if t == "" else t[: len(t) - len(words[-1])]
 
         self.set_edit_text(f_text + text[self.edit_pos :])
         self.set_edit_pos(len(f_text))
@@ -97,10 +94,7 @@ class ExtendedEdit(urwid.Edit):
         text = self.get_edit_text()
         eol = text.find("\n", self.edit_pos)
 
-        if eol == -1:
-            after_eol = ""
-        else:
-            after_eol = text[eol:]
+        after_eol = "" if eol == -1 else text[eol:]
 
         self.set_edit_text(text[: self.edit_pos] + after_eol)
 


### PR DESCRIPTION
Ruff is a newer linter which re-implements flake8 (plus a few of its plugins),
isort and pyupgrade into one single codebase. It's stupid fast, and after some
testing is proving to be quite reliable.