### PR TITLE
fix filtering for non-ASCII categories

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -72,11 +72,20 @@ def test_category(tmpdir, runner, create):
     create("one.ics", f"UID:{uuid4()}\nSUMMARY:haha\nCATEGORIES:work,trip\n")
     create("two.ics", "CATEGORIES:trip\nSUMMARY:hoho\n")
     create("three.ics", f"UID:{uuid4()}\nSUMMARY:harhar\n")
+    create("four.ics", f"UID:{uuid4()}\nSUMMARY:harharho\nCATEGORIES:ý,Дом\n")
     result = runner.invoke(cli, ["list", "--category", "work"])
     assert not result.exception
     assert "haha" in result.output
     assert "hoho" not in result.output
     assert "harhar" not in result.output
+
+    # non-ASCII categories
+    result = runner.invoke(cli, ["list", "--category", "ý"])
+    assert not result.exception
+    assert "harharho" in result.output
+    result = runner.invoke(cli, ["list", "--category", "Дом"])
+    assert not result.exception
+    assert "harharho" in result.output
 
 
 def test_grep(tmpdir, runner, create):


### PR DESCRIPTION
To make category filtering case insensitive, todoman converts the
category provided on the commandline to uppercase, uses the sqlite
`upper` function to convert the cache entries and then compares the
converted strings.

However the sqlite `upper` function only works for ASCII strings causing
problems when the category is for instance `ý`, which sqlite translates
to uppercase as `ý` while the correct version is `Ý`, causing the
filtering for this category not to return any tasks.

Add a new column (`category_upper`) to the `categories` table with the
uppercase version of the category name converted by Python (which
performs the conversion correctly) and use this for filtering while
keeping the original version in the `category` column as before.

Add a corresponding test.

---
Fixes #540.

<!--

Items to keep in mind:

- When opening a PR, tests will be run on the PR, and you'll be notified if any
  of these tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for you.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->
