### PR TITLE
docs: drop sphinx-autorun dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ v4.5.0
 * The ``PRODID`` for new entries has changed ``io.barrera.todoman`` to
   ``nl.whynothugo.todoman``. This has no functional impact, but may be relevant
   when debugging the origin of specific files.
+* Drop ``sphinx-autorun`` dependency for the docs as it has been unused for some
+  time now anyway.
 
 v4.4.0
 ------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,6 @@ with open("confspec.tmp", "w") as file_:
 extensions = [
     "sphinx_click.ext",
     "sphinx.ext.autodoc",
-    "sphinx_autorun",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_rtd_theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ test = [
     "ruff",
 ]
 docs = [
-    "sphinx_autorun",
     "sphinx-click",
     "sphinx_rtd_theme",
 ]


### PR DESCRIPTION
This has been unused since 771160793ea1.

<!--

Items to keep in mind:

- When opening a PR, tests will be run on the PR, and you'll be notified if any
  of these tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for you.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->
