### PR TITLE
Remove deprecated pytest-runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ test = [
     "hypothesis",
     "pytest",
     "pytest-cov",
-    "pytest-runner",
 ]
 docs = [
     "sphinx-click",


### PR DESCRIPTION
We don't seem to actually be relying on this anyway.

Fixes: https://github.com/pimutils/todoman/issues/559
