### PR TITLE
explicitly depend on pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "icalendar>=4.0.3",
     "parsedatetime",
     "python-dateutil",
+    "pytz",
     "pyxdg",
     "urwid",
 ]


### PR DESCRIPTION
icalendar removed the dependency in v6

<!--

Items to keep in mind:

- When opening a PR, tests will be run on the PR, and you'll be notified if any
  of these tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for you.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->
