### PR TITLE
fix(pyproject): add pytz dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "icalendar>=4.0.3",
     "parsedatetime",
     "python-dateutil",
+    "pytz",
     "pyxdg",
     "urwid",
 ]


### PR DESCRIPTION
missing pytz dep in pyproject

relates to https://github.com/Homebrew/homebrew-core/pull/193639