### PR TITLE
ci: run tests on Python 3.9

### DIFF
--- a/.builds/debian-py39.yml
+++ b/.builds/debian-py39.yml
@@ -1,0 +1,26 @@
+image: debian/bullseye
+packages:
+  - libicu-dev
+  - python3-dev
+  - python3-pip
+  - tox
+sources:
+  - https://github.com/pimutils/todoman
+environment:
+  CODECOV_TOKEN: a4471483-7f55-411a-bf2f-f65a91013dc4
+  CI: true
+tasks:
+  - setup: |
+      sudo pip install codecov
+  - test: |
+      cd todoman
+      tox -e py
+      codecov
+  - test-pyicu: |
+      cd todoman
+      tox -e pyicu
+      codecov
+  - test-repl: |
+      cd todoman
+      tox -e repl
+      codecov


### PR DESCRIPTION
Run tests and checks with the oldest supported version of Python too.