### PR TITLE
cli/edit: allow empty due dates in non-interactive mode

### DIFF
--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -508,7 +508,7 @@ def edit(
 
     changes = False
     for key, value in todo_properties.items():
-        if value is not None and value != []:
+        if (value is not None or key in ['due']) and value != []:
             changes = True
             setattr(todo, key, value)
 


### PR DESCRIPTION
I ran into the necessity to batch-edit a bunch of tasks to unset the due date, and in doing so found that there's no supported way to "unset" it without using the interactive mode. 

This PR aims to fix that. The current fix is somewhat quick-n-dirty, and I think it would be better to dynamically detect if the field is allowed to be `None` by using type annotations, but I'm just starting to dig into the codebase so I want to post it here first!

Anyways, thanks for all the work in the project :)