### PR TITLE
Docs: `:show-nested:` is deprecated

### DIFF
--- a/docs/source/man.rst
+++ b/docs/source/man.rst
@@ -3,7 +3,7 @@ Man page
 
 .. click:: todoman.cli:cli
    :prog: todo
-   :show-nested:
+   :nested: short
 
 Description
 -----------


### PR DESCRIPTION
From the `sphinx-click` docs

> This option is deprecated; use nested instead.

Read more https://sphinx-click.readthedocs.io/en/latest/usage/#usage


<!--

Items to keep in mind:

- When opening a PR, tests will be run on the PR, and you'll be notified if any
  of these tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for you.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->
