### PR TITLE
Remove H1 from content files for usage and configure

### DIFF
--- a/docs/source/_configure.rst
+++ b/docs/source/_configure.rst
@@ -1,6 +1,3 @@
-Configuring
-===========
-
 You'll need to configure Todoman before the first usage, using its simple
 ini-like configuration file.
 

--- a/docs/source/_usage.rst
+++ b/docs/source/_usage.rst
@@ -1,6 +1,3 @@
-Usage
-=====
-
 Todoman usage is `CLI`_ based (thought there are some TUI bits, and the
 intentions is to also provide a fully `TUI`_-based interface).
 


### PR DESCRIPTION
Sorry, I forgot to remove titles (H1) from content files

<!--

Items to keep in mind:

- When opening a PR, tests will be run on the PR, and you'll be notified if any
  of these tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for you.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->
