### PR TITLE
Use InteractiveFormatter intermediate type

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -101,6 +101,7 @@ def test_format_datetime(default_formatter: DefaultFormatter) -> None:
         default_formatter.format_datetime(datetime(2017, 3, 4, 17, 00))
         == "2017-03-04 17:00"
     )
+    assert default_formatter.format_datetime(None) == ""
 
 
 def test_detailed_format(runner: CliRunner, todo_factory: Callable) -> None:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from urwid import ExitMainLoop
 
 from todoman.formatters import DefaultFormatter
-from todoman.formatters import Formatter
+from todoman.formatters import InteractiveFormatter
 from todoman.interactive import TodoEditor
 from todoman.model import Database
 
@@ -37,7 +37,7 @@ def test_todo_editor_priority(
 def test_todo_editor_list(
     default_database: Database,
     todo_factory: Callable,
-    default_formatter: Formatter,
+    default_formatter: InteractiveFormatter,
     tmpdir: py.path.local,
 ) -> None:
     tmpdir.mkdir("another_list")
@@ -70,7 +70,7 @@ def test_todo_editor_list(
 def test_todo_editor_summary(
     default_database: Database,
     todo_factory: Callable,
-    default_formatter: Formatter,
+    default_formatter: InteractiveFormatter,
 ) -> None:
     todo = todo_factory()
     lists = list(default_database.lists())
@@ -109,7 +109,7 @@ def test_todo_editor_due(
 
 def test_toggle_help(
     default_database: Database,
-    default_formatter: Formatter,
+    default_formatter: InteractiveFormatter,
     todo_factory: Callable,
 ) -> None:
     todo = todo_factory()
@@ -139,7 +139,7 @@ def test_toggle_help(
 
 def test_show_save_errors(
     default_database: Database,
-    default_formatter: Formatter,
+    default_formatter: InteractiveFormatter,
     todo_factory: Callable,
 ) -> None:
     todo = todo_factory()
@@ -162,7 +162,7 @@ def test_show_save_errors(
 def test_save_completed(
     check: bool,
     completed: bool,
-    default_formatter: Formatter,
+    default_formatter: InteractiveFormatter,
     todo_factory: Callable,
 ) -> None:
     todo = todo_factory()
@@ -177,7 +177,10 @@ def test_save_completed(
 
 
 @pytest.mark.skip("See: https://github.com/pimutils/todoman/issues/537")
-def test_ctrl_c_clears(default_formatter: Formatter, todo_factory: Callable) -> None:
+def test_ctrl_c_clears(
+    default_formatter: InteractiveFormatter,
+    todo_factory: Callable,
+) -> None:
     todo = todo_factory()
     editor = TodoEditor(todo, [todo.list], default_formatter)
 

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -258,7 +258,7 @@ class AppContext:
     formatter_class: type[formatters.Formatter]
 
     @cached_property
-    def ui_formatter(self) -> formatters.Formatter:
+    def ui_formatter(self) -> formatters.InteractiveFormatter:
         return formatters.DefaultFormatter(
             self.config["date_format"],
             self.config["time_format"],

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -201,9 +201,7 @@ class DefaultFormatter(Formatter):
             return ""
         if isinstance(dt, datetime):
             return dt.strftime(self.datetime_format)
-        if isinstance(dt, date):
-            return dt.strftime(self.date_format)
-        return None
+        return dt.strftime(self.date_format)
 
     def format_categories(self, categories: Iterable[str]) -> str:
         return ", ".join(categories)

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -74,26 +74,49 @@ class Formatter(ABC):
     def parse_datetime(self, value: str | None) -> date | None:
         """Parse an optional datetime."""
 
-    @abstractmethod
-    def format_database(self, database: TodoList) -> str:
-        """Format the name of a single database."""
-
     def parse_categories(self, categories: str) -> list[str]:
         """Parse multiple categories."""
         # existing code assumes categories is list,
         # but click passes tuple
         return list(categories)
 
+
+class InteractiveFormatter(Formatter):
+    """Formatter usable in the TUI"""
+
     @abstractmethod
+    def __init__(
+        self,
+        date_format: str = "%Y-%m-%d",
+        time_format: str = "%H:%M",
+        dt_separator: str = " ",
+    ) -> None:
+        """Create a new formatter instance."""
+
     def format_categories(self, categories: Iterable[str]) -> str:
         """Format multiple categories."""
+        return ", ".join(categories)
 
-    @abstractmethod
+    def format_database(self, database: TodoList) -> str:
+        """Format the name of a single database."""
+        return "{}@{}".format(
+            rgb_to_ansi(database.colour) or "", click.style(database.name)
+        )
+
     def format_priority(self, priority: int | None) -> str:
-        """Format a todo priority"""
+        if not priority:
+            return "none"
+        if 1 <= priority <= 4:
+            return "high"
+        if priority == 5:
+            return "medium"
+        if 6 <= priority <= 9:
+            return "low"
+
+        raise ValueError("priority is an invalid value")
 
 
-class DefaultFormatter(Formatter):
+class DefaultFormatter(InteractiveFormatter):
     def __init__(
         self,
         date_format: str = "%Y-%m-%d",
@@ -197,16 +220,12 @@ class DefaultFormatter(Formatter):
 
         return f"{self.compact(todo)}{''.join(extra_lines)}"
 
-    # FIXME: cannot return `int`, but porcelain subclasses this (it shouldn't)
-    def format_datetime(self, dt: date | None) -> str | int | None:
+    def format_datetime(self, dt: date | None) -> str | None:
         if not dt:
             return ""
         if isinstance(dt, datetime):
             return dt.strftime(self.datetime_format)
         return dt.strftime(self.date_format)
-
-    def format_categories(self, categories: Iterable[str]) -> str:
-        return ", ".join(categories)
 
     def parse_priority(self, priority: str | None) -> int | None:
         if priority is None or priority == "":
@@ -220,18 +239,6 @@ class DefaultFormatter(Formatter):
         if priority == "none":
             return 0
         raise ValueError("Priority has to be one of low, medium, high or none")
-
-    def format_priority(self, priority: int | None) -> str:
-        if not priority:
-            return "none"
-        if 1 <= priority <= 4:
-            return "high"
-        if priority == 5:
-            return "medium"
-        if 6 <= priority <= 9:
-            return "low"
-
-        raise ValueError("priority is an invalid value")
 
     def format_priority_compact(self, priority: int | None) -> str:
         if not priority:
@@ -270,11 +277,6 @@ class DefaultFormatter(Formatter):
             raise ValueError(f"Time description not recognized: {dt}")
         return datetime.fromtimestamp(mktime(rv))
 
-    def format_database(self, database: TodoList) -> str:
-        return "{}@{}".format(
-            rgb_to_ansi(database.colour) or "", click.style(database.name)
-        )
-
 
 class HumanizedFormatter(DefaultFormatter):
     def format_datetime(self, dt: date | None) -> str:
@@ -291,7 +293,17 @@ class HumanizedFormatter(DefaultFormatter):
         return rv
 
 
-class PorcelainFormatter(DefaultFormatter):
+class PorcelainFormatter(Formatter):
+    def __init__(
+        self,
+        date_format: str = "%Y-%m-%d",
+        time_format: str = "%H:%M",
+        dt_separator: str = " ",
+        tz_override: tzinfo | None = None,
+    ) -> None:
+        # tz_override is accepted for compatibility but not used - porcelain uses UTC
+        pass
+
     def _todo_as_dict(self, todo: Todo) -> dict:
         return {
             "completed": todo.is_completed,

--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -78,9 +78,11 @@ class Formatter(ABC):
     def format_database(self, database: TodoList) -> str:
         """Format the name of a single database."""
 
-    @abstractmethod
     def parse_categories(self, categories: str) -> list[str]:
         """Parse multiple categories."""
+        # existing code assumes categories is list,
+        # but click passes tuple
+        return list(categories)
 
     @abstractmethod
     def format_categories(self, categories: Iterable[str]) -> str:
@@ -205,11 +207,6 @@ class DefaultFormatter(Formatter):
 
     def format_categories(self, categories: Iterable[str]) -> str:
         return ", ".join(categories)
-
-    def parse_categories(self, categories: str) -> list[str]:
-        # existing code assumes categories is list,
-        # but click passes tuple
-        return list(categories)
 
     def parse_priority(self, priority: str | None) -> int | None:
         if priority is None or priority == "":

--- a/todoman/interactive.py
+++ b/todoman/interactive.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import typing
+from typing import TYPE_CHECKING
 
 import urwid
 
 from todoman import widgets
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from todoman.formatters import Formatter

--- a/todoman/interactive.py
+++ b/todoman/interactive.py
@@ -9,7 +9,7 @@ from todoman import widgets
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from todoman.formatters import Formatter
+    from todoman.formatters import InteractiveFormatter
     from todoman.model import Todo
     from todoman.model import TodoList
 
@@ -25,7 +25,7 @@ class TodoEditor:
         self,
         todo: Todo,
         lists: Iterable[TodoList],
-        formatter: Formatter,
+        formatter: InteractiveFormatter,
     ) -> None:
         """
         :param model.Todo todo: The todo object which will be edited.


### PR DESCRIPTION
PorcelainFormatter has different return types for a few methods compared
to the other two formatter. The Formatter abstract type attempts to
reflect this in the declared return types, but this merely pollutes the
interface. In reality, PorcelainFormatter is not usable in all places
where the other formatter are usable (e.g.: with the interactive
editor).

Declare an intermediate abstract InteractiveFormatter class for the
formatter that are usable with the interactive editor, and move the
related methods there, removing them from the parent Formatter class.

Fixes: https://github.com/pimutils/todoman/pull/606

