### PR TITLE
fix: eliminate double space when priority is not set

### DIFF
--- a/todoman/formatters.py
+++ b/todoman/formatters.py
@@ -157,10 +157,10 @@ class DefaultFormatter(Formatter):
 
             # TODO: add spaces on the left based on max todos"
 
-            # FIXME: double space when no priority
             # split into parts to satisfy linter line too long
+            priority_str = f"{priority} " if priority else ""
             table.append(
-                f"[{completed}] {todo.id} {priority} {due} "
+                f"[{completed}] {todo.id} {priority_str}{due} "
                 f"{recurring}{summary}{categories}"
             )
 


### PR DESCRIPTION
Fixed a bug I found while browsing. The compact_multiple formatter was adding a space after the priority column even when no priority was set (empty string), causing double spacing between the todo ID and the due date. The fix uses conditional logic to only add the priority and its trailing space when the priority string is non-empty.

**Before:**
`[{completed}] {todo.id} { } {due} ...` (double space when no priority)

**After:**
`[{completed}] {todo.id} {due} ...` (single space)

Fixes the FIXME comment at formatters.py line 185. — Sent via @AmSach bot