### PR TITLE
cli/edit: add --summary option to edit task summary

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -549,6 +549,22 @@ def test_edit(runner: CliRunner, default_database: Database, todos: Callable) ->
     assert todo.summary == "Eat paint"
 
 
+def test_edit_summary(
+    runner: CliRunner, default_database: Database, todos: Callable
+) -> None:
+    todo = Todo(new=True)
+    todo.list = next(default_database.lists())
+    todo.summary = "Eat paint"
+    default_database.save(todo)
+
+    result = runner.invoke(cli, ["edit", "1", "--summary", "Eat soup"])
+    assert not result.exception
+    assert "Eat soup" in result.output
+
+    todo = next(todos(status="ANY"))
+    assert todo.summary == "Eat soup"
+
+
 def test_edit_move(
     runner: CliRunner,
     todo_factory: Callable,

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -471,6 +471,11 @@ def new(
 @cli.command()
 @pass_ctx
 @click.option(
+    "--summary",
+    default=None,
+    help="Summary (title) of the task.",
+)
+@click.option(
     "--read-description",
     "-r",
     is_flag=True,
@@ -496,6 +501,7 @@ def edit(
     interactive: bool,
     read_description: bool,
     raw: bool,
+    summary: str | None,
 ) -> None:
     """
     Edit the task with id ID.
@@ -511,6 +517,10 @@ def edit(
         if value is not None and value != []:
             changes = True
             setattr(todo, key, value)
+
+    if summary is not None:
+        changes = True
+        todo.summary = summary
 
     if read_description:
         changes = True


### PR DESCRIPTION
<!--

Items to keep in mind:

- When opening a PR, tests will be run on the PR, and you'll be notified if any
  of these tests fail.
- The same applies to documentation; if there's any breakage, CI will check
  this for you.
- Make sure you're using `pre-commit` locally to run any fixes/checks.

See the relevant documentation for more details:

https://todoman.readthedocs.io/en/stable/contributing.html#patch-review-checklist

-->

Resolves #605. Adds `--summary` to the `edit` subcommand so the task title can be changed non-interactively, matching the "Patches welcome" response on the issue.