### PR TITLE
Allow configuration of multiple paths

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1046,6 +1046,56 @@ def test_porcelain_precedence(runner: CliRunner, tmpdir: py.path.local) -> None:
     assert mocked_formatter.call_count == 1
 
 
+def test_path_and_paths_entry(
+    tmpdir: py.path.local,
+    runner: CliRunner,
+    create: Callable,
+    config: py.path.local,
+) -> None:
+    config.write(f'path = "{tmpdir}"\n', "a")
+    config.write(f'paths = ["{tmpdir}"]\n', "a")
+
+    result = runner.invoke(cli, ["list"])
+    assert result.exception
+    assert "Both 'path' and 'paths' is set, use one." in str(result.exception)
+
+
+def test_duplicated_expanded_directories(
+    tmpdir: py.path.local,
+    runner: CliRunner,
+    create: Callable,
+    config: py.path.local,
+) -> None:
+    parent = tmpdir.dirname
+    config.write(f'paths = ["{tmpdir}", "{parent}/*"]\n')
+
+    result = runner.invoke(cli, ["list"])
+    assert result.exception
+    assert result.exit_code == exceptions.DuplicatedPathError.EXIT_CODE
+
+
+def test_list_multiple_paths(
+    tmpdir: py.path.local,
+    runner: CliRunner,
+    create: Callable,
+    config: py.path.local,
+) -> None:
+    tmpdir.join("dir1").mkdir()
+    tmpdir.join("dir2").mkdir()
+    config.write(f'paths = ["{tmpdir.join("dir1")}", "{tmpdir.join("dir2")}"]\n')
+
+    result = runner.invoke(cli, ["list"], catch_exceptions=False)
+    assert not result.exception
+
+    create("test.ics", f"UID:{uuid4()}\nSUMMARY:from1\n", "dir1")
+    create("test.ics", f"UID:{uuid4()}\nSUMMARY:from2\n", "dir2")
+
+    result = runner.invoke(cli, ["list"])
+    assert not result.exception
+    assert "from1" in result.output
+    assert "from2" in result.output
+
+
 def test_duplicate_list(tmpdir: py.path.local, runner: CliRunner) -> None:
     tmpdir.join("personal1").mkdir()
     with tmpdir.join("personal1").join("displayname").open("w") as f:

--- a/todoman/cli.py
+++ b/todoman/cli.py
@@ -21,7 +21,9 @@ import click_log
 
 from todoman import exceptions
 from todoman import formatters
+from todoman.configuration import CONFIG_SPEC
 from todoman.configuration import ConfigurationError
+from todoman.configuration import expand_path
 from todoman.configuration import load_config
 from todoman.interactive import TodoEditor
 from todoman.model import Database
@@ -205,6 +207,15 @@ def validate_status(ctx: AppContext, param: click.Parameter, val: str) -> str:
     return val
 
 
+def glob_path(path: str) -> list[str]:
+    paths = [
+        path
+        for path in glob.iglob(path)
+        if isdir(path) and not path.endswith("__pycache__")
+    ]
+    return paths
+
+
 def _todo_property_options(command: Callable) -> Callable:
     click.option(
         "--category",
@@ -360,13 +371,23 @@ def cli(
     elif colour == "never":
         click_ctx.color = False
 
-    paths = [
-        path
-        for path in glob.iglob(ctx.config["path"])
-        if isdir(path) and not path.endswith("__pycache__")
-    ]
+    # XXX: There is no good way to check if an option has been explicitly set.
+    default_path = expand_path(CONFIG_SPEC[0].default)
+    if ctx.config["path"] != default_path and len(ctx.config["paths"]) != 0:
+        raise ConfigurationError("Both 'path' and 'paths' is set, use one.")
+
+    # If "paths" is unset, fallback to the old "path" config option.
+    paths = ctx.config["paths"]
     if len(paths) == 0:
-        raise exceptions.NoListsFoundError(ctx.config["path"])
+        paths = glob_path(ctx.config["path"])
+        if len(paths) == 0:
+            raise exceptions.NoListsFoundError(ctx.config["path"])
+    else:
+        paths = [p for x in paths for p in glob_path(x)]
+        if len(paths) == 0:
+            raise exceptions.NoListsFoundError(ctx.config["paths"])
+        elif len(paths) != len(set(paths)):
+            raise exceptions.DuplicatedPathError(ctx.config["paths"])
 
     ctx.db = Database(paths, ctx.config["cache_path"])
     click_ctx.call_on_close(ctx.db.close)

--- a/todoman/configuration.py
+++ b/todoman/configuration.py
@@ -19,6 +19,10 @@ def expand_path(path: str) -> str:
     return os.path.expanduser(os.path.expandvars(path))
 
 
+def expand_paths(paths: list[str]) -> list[str]:
+    return list(map(expand_path, paths))
+
+
 def validate_cache_path(path: str) -> str:
     path = path.replace("$XDG_CACHE_HOME", xdg.BaseDirectory.xdg_cache_home)
     return expand_path(path)
@@ -73,6 +77,16 @@ A glob pattern matching the directories where your todos are located. This
 pattern will be expanded, and each matching directory (with any icalendar
 files) will be treated as a list.""",
         expand_path,
+    ),
+    ConfigEntry(
+        "paths",
+        list,
+        [],
+        """
+A list of glob patterns matching directories where your todos are located.
+If unset, this defaults to the value of the ``path`` configuration option.
+""",
+        expand_paths,
     ),
     ConfigEntry(
         "color",

--- a/todoman/exceptions.py
+++ b/todoman/exceptions.py
@@ -52,3 +52,10 @@ class AlreadyExistsError(TodomanError):
 
     def __str__(self) -> str:
         return "More than one {} has the same identity: {}.".format(*self.args)
+
+
+class DuplicatedPathError(TodomanError):
+    EXIT_CODE = 24
+
+    def __str__(self) -> str:
+        return f"List {self.args[0]} contains duplicated entries after glob expansion."


### PR DESCRIPTION
For my work machine, I want to be able to access both my private and work-related to-dos. Unfortunately, they are stored in two entirely different directories, which I cannot easily match using a single `glob(3)` expression. For this kind of use case, this PR introduces a new configuration variable called `paths` which can be set to *a list of `glob(3)` expressions* to include multiple directories with `.ics` files.

The proposed patch is backwards compatible with the previous configuration format as the list's value defaults to a single-element list containing the value of the previous `path` configuration option, if the `paths` option is unset.

I intentionally tried to implement this in a way that retains backwards compatibility, I would also be open to other designs. For example, making the existing `path` configuration option a list of strings instead of a string. I haven't added tests yet but can do so once we agreed on a design. 